### PR TITLE
Fix for Issue#61: Restarting tink will not reset the database and hardware data will persist. 

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -19,12 +19,6 @@ func ConnectDB(lg log.Logger) *sql.DB {
 		logger.Error(err)
 		panic(err)
 	}
-	if err := truncate(db); err != nil {
-		if pqErr := Error(err); pqErr != nil {
-			logger.With("detail", pqErr.Detail, "where", pqErr.Where).Error(err)
-		}
-		panic(err)
-	}
 	return db
 }
 
@@ -34,24 +28,6 @@ func Error(err error) *pq.Error {
 		return pqErr
 	}
 	return nil
-}
-
-func truncate(db *sql.DB) error {
-	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
-	if err != nil {
-		return errors.Wrap(err, "BEGIN transaction")
-	}
-
-	_, err = tx.Exec("TRUNCATE hardware")
-	if err != nil {
-		return errors.Wrap(err, "TRUNCATE")
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		return errors.Wrap(err, "TRUNCATE")
-	}
-	return err
 }
 
 func get(ctx context.Context, db *sql.DB, query string, args ...interface{}) (string, error) {


### PR DESCRIPTION
Root Cause of issue:
      When tink tries to start it calls connecetdb  which was creating the connection with the db and calling the trauncate function which trucate the hardware table in the database because of which all the entries in the hardware table were being deleted.

Fix:
       I have removed the tructate function because of which trucation of harware table will not happen and all the entries of harware table will persist as it is even after the restart of tink.