### PR TITLE
docs/writing-workflow.md: fix missing MAC address in worker field

### DIFF
--- a/docs/writing-workflow.md
+++ b/docs/writing-workflow.md
@@ -93,7 +93,7 @@ name: ubuntu_provisioning
 global_timeout: 2500
 tasks:
 - name: "os-installation"
-  worker: ""
+  worker: "98:03:9b:4b:c5:34"
   volumes:
     - /dev:/dev
     - /lib/firmware:/lib/firmware:ro


### PR DESCRIPTION
The `worker` value should be set to hardware MAC address, even the sentence below the example mentions that.