### PR TITLE
Fixes #38: Using persistent volume to hold registry data

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       REGISTRY_AUTH_HTPASSWD_PATH: /auth/htpasswd
     volumes:
       - ./certs:/certs
+      - /var/tinkerbell/registry:/var/lib/registry
     depends_on:
       fluentbit:
         condition: service_started

--- a/setup.sh
+++ b/setup.sh
@@ -344,6 +344,10 @@ start_registry() {
 }
 
 setup_docker_registry() {
+	registry_images=/var/tinkerbell/registry
+	if [ ! -d "$registry_images" ]; then
+		mkdir -p "$registry_images"
+	fi
 	if [ -f ~/.docker/config.json ]; then 
 		if grep -q "$TINKERBELL_HOST_IP" ~/.docker/config.json; then
 			echo "$INFO found existing docker auth token for registry $TINKERBELL_HOST_IP, using existing registry"


### PR DESCRIPTION
In this fix we are using "/var/tinkerbell/registry" directory locally to persist the data of private registry we are creating to have worker and action images. 