### PR TITLE
docs/setup.md: remove trailing whitespace

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,8 +1,8 @@
 # Setup the Provisioner
 
 ### Prerequisites
- - The setup must be executed as a privileged or root user. 
- - The setup downloads about 1.5GB of assets, therefore, it is advised to have a minimum of 10GB disk space available before you begin. 
+ - The setup must be executed as a privileged or root user.
+ - The setup downloads about 1.5GB of assets, therefore, it is advised to have a minimum of 10GB disk space available before you begin.
 
 ### Interactive Mode
 Execute the following commands to bring up the Tinkerbell stack with an interactive setup:
@@ -26,15 +26,15 @@ $ curl https://raw.githubusercontent.com/tinkerbell/tink/master/setup.sh | bash
 ```
 
 ### Good to know
- - All the environment variables are kept in the `envrc` file, which is generated from the setup itself.  
- - It is advised that you keep all the environment variables in the same file. 
+ - All the environment variables are kept in the `envrc` file, which is generated from the setup itself.
+ - It is advised that you keep all the environment variables in the same file.
  - It is important to note that if you execute the setup the again, a new `envrc` will be generated. However, the existing environment configuration be saved as `envrc.bak`.
  - The setup removes all the `.tar.gz` files downloaded in process.
 
 ### For Packet Environment
 
 The script was tested with:
- - Server class: `c3.small.x86` 
+ - Server class: `c3.small.x86`
  - Operating System: Ubuntu 18.04 and CentOS 7
  - Region: Amsterdam, NL (AMS1)
  - ENV variables:
@@ -43,7 +43,7 @@ The script was tested with:
   export TB_NETWORK=192.168.1.0/29
   export TB_IPADDR=192.168.1.1
   export TB_REGUSER=admin
- ``` 
+ ```
  - Command:
  ```shell
  $ curl https://raw.githubusercontent.com/tinkerbell/tink/master/setup.sh | bash


### PR DESCRIPTION
It seems it was mistakenly added in 0105667789d11069be31ee6cd14cd2f4b33a2ac5.