### PR TITLE
Reading hardware data from stdin

### DIFF
--- a/cli/tink/cmd/hardware/push.go
+++ b/cli/tink/cmd/hardware/push.go
@@ -3,7 +3,6 @@
 package hardware
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,8 +17,8 @@ import (
 )
 
 var (
-	filePath string
-	fPath    = "file-path"
+	file  string
+	sFile = "file"
 )
 
 // pushCmd represents the push command
@@ -27,12 +26,12 @@ var pushCmd = &cobra.Command{
 	Use:   "push",
 	Short: "Push new hardware to tinkerbell",
 	Example: `cat /tmp/data.json | tink hardware push
-tink hardware push -p /tmp/data.json`,
+tink hardware push --file /tmp/data.json`,
 	PreRunE: func(c *cobra.Command, args []string) error {
 		if !isInputFromPipe() {
-			path, _ := c.Flags().GetString(fPath)
+			path, _ := c.Flags().GetString(sFile)
 			if path == "" {
-				return fmt.Errorf("%v either pipe the data or provide the required flag", c.UseLine())
+				return fmt.Errorf("either pipe the data or provide the required '--file' flag")
 			}
 		}
 		return nil
@@ -65,15 +64,15 @@ func isInputFromPipe() bool {
 }
 
 func readDataFromStdin() string {
-	scanner := bufio.NewScanner(bufio.NewReader(os.Stdin))
-	for scanner.Scan() {
-		return scanner.Text()
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return ""
 	}
-	return ""
+	return string(data)
 }
 
 func readDataFromFile() string {
-	f, err := os.Open(filePath)
+	f, err := os.Open(file)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -88,7 +87,7 @@ func readDataFromFile() string {
 
 func init() {
 	flags := pushCmd.PersistentFlags()
-	flags.StringVarP(&filePath, "file-path", "p", "", "path to the hardware data file")
+	flags.StringVarP(&file, "file", "", "", "hardware data file")
 
 	SubCommands = append(SubCommands, pushCmd)
 }

--- a/cli/tink/cmd/hardware/push.go
+++ b/cli/tink/cmd/hardware/push.go
@@ -6,7 +6,8 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"io"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -16,13 +17,33 @@ import (
 	"github.com/tinkerbell/tink/protos/hardware"
 )
 
+var (
+	filePath string
+	fPath    = "file-path"
+)
+
 // pushCmd represents the push command
 var pushCmd = &cobra.Command{
-	Use:     "push",
-	Short:   "Push new hardware to tinkerbell",
-	Example: "cat data.json | tink hardware push",
+	Use:   "push",
+	Short: "Push new hardware to tinkerbell",
+	Example: `cat /tmp/data.json | tink hardware push
+tink hardware push -p /tmp/data.json`,
+	PreRunE: func(c *cobra.Command, args []string) error {
+		if !isInputFromPipe() {
+			path, _ := c.Flags().GetString(fPath)
+			if path == "" {
+				return fmt.Errorf("%v either pipe the data or provide the required flag", c.UseLine())
+			}
+		}
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
-		data := readHardwareData(os.Stdin)
+		var data string
+		if isInputFromPipe() {
+			data = readDataFromStdin()
+		} else {
+			data = readDataFromFile()
+		}
 		s := struct {
 			ID string
 		}{}
@@ -38,14 +59,36 @@ var pushCmd = &cobra.Command{
 	},
 }
 
-func readHardwareData(r io.Reader) string {
-	scanner := bufio.NewScanner(bufio.NewReader(r))
+func isInputFromPipe() bool {
+	fileInfo, _ := os.Stdin.Stat()
+	return fileInfo.Mode()&os.ModeCharDevice == 0
+}
+
+func readDataFromStdin() string {
+	scanner := bufio.NewScanner(bufio.NewReader(os.Stdin))
 	for scanner.Scan() {
 		return scanner.Text()
 	}
 	return ""
 }
 
+func readDataFromFile() string {
+	f, err := os.Open(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return string(data)
+}
+
 func init() {
+	flags := pushCmd.PersistentFlags()
+	flags.StringVarP(&filePath, "file-path", "p", "", "path to the hardware data file")
+
 	SubCommands = append(SubCommands, pushCmd)
 }


### PR DESCRIPTION
At present, the hardware data is pushed as shown below and is not the right (or best) way to do it:
```
$ tink hardware push 'hadware-data-json'
```

With the code changes in place, a user can now pipe the hardware data from a JSON file. For example, if the data is saved in `/tmp/data.json`, you can push the data with either of the following:
```
$ cat /tmp/data.json | tink hardware push
$ tink hardware push --file /tmp/data.json
```
Also, if there is no error a confirmation message saying `Hardware data pushed successfully` is received after the data is pushed.

Signed-off-by: Gaurav Gahlot <gaurav.gahlot19@gmail.com>