### PR TITLE
Accept path to OSIE tar as env for tinkerbell setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -296,8 +296,14 @@ setup_osie() {
 		mkdir -p "$osie_current"
     	mkdir -p "$tink_workflow"
     	pushd /tmp
-    	curl 'https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/latest.tar.gz' -o osie.tar.gz
-    	tar -zxf osie.tar.gz
+
+        if [ -z "${TB_OSIE_TAR:-}" ]; then
+            curl 'https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/latest.tar.gz' -o osie.tar.gz
+            tar -zxf osie.tar.gz
+        else
+            tar -zxf "$TB_OSIE_TAR"
+        fi
+
     	if pushd /tmp/osie*/ ; then
 			if mv workflow-helper.sh workflow-helper-rc "$tink_workflow"; then
 				cp -r ./* "$osie_current"


### PR DESCRIPTION
As the `setup.sh` executes, it downloads the latest of Osie. This will not efficient for local setup with Vagrant, as you may have to destroy your provisioner VM for various reasons. 

The setup script will first read the `TB_OSIE_TAR` variable. If it is set, the setup will skip the download and extract the file provided `tar` instead. If not, it will go ahead and download the latest of Osie.

For your Vagrant setup, you can download the tar and then sync the containing directory with the provisioner VM. Now, set the environment variable to the synced folder. For instance:
```
// in Vagrantfile
config.vm.synced_folder '/var/osie', '/vagrant', type: 'rsync'

// export the env
export TB_OSIE_TAR=/vagrant/latest.tar.gz
```
Signed-off-by: Gaurav Gahlot <gaurav.gahlot19@gmail.com>