### PR TITLE
editorconfig: init

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[{Makefile,go.mod,go.sum,*.go,.gitmodules,*.sh}]
+indent_style = tab
+indent_size = 8
+
+[*.md]
+indent_size = 4


### PR DESCRIPTION
I noticed the setup.sh script is a bit confused about indentation. If
everybody sets up an editorconfig plugin for their editor, their
editor will automatically configure itself:
https://editorconfig.org/#download