### PR TITLE
Enable auto merge using Mergify on approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,13 @@
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - base=master
+      - "#approved-reviews-by>=1"
+      - label=ready-to-merge
+      - label!=hold-off-merging
+      - status-success=CI / build
+    actions:
+      merge:
+        method: squash
+        commit_message: title+body
+        strict: smart

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,6 @@ pull_request_rules:
       - status-success=CI / build
     actions:
       merge:
-        method: squash
+        method: rebase
         commit_message: title+body
-        strict: smart
+        strict: smart+fastpath


### PR DESCRIPTION
Enable auto-merge using Mergify on approval.

Workflow:
- Developer opens a PR
- Reviewer approves the changes and adds `ready-to-merge` label
- Mergify runs CI again and merges the PR
- Mergify holds the auto-merge if `hold-off-merging` label is set

Signed-off-by: Gaurav Gahlot <gaurav.gahlot19@gmail.com>