### PR TITLE
Tweak mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,5 @@ pull_request_rules:
       - status-success=CI / build
     actions:
       merge:
-        method: rebase
         commit_message: title+body
         strict: smart+fastpath

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,9 @@ pull_request_rules:
     conditions:
       - base=master
       - "#approved-reviews-by>=1"
+      - "#review-requested=0"
+      - "#changes-requested-reviews-by=0"
+      - "#commented-reviews-by=0"
       - label=ready-to-merge
       - label!=hold-off-merging
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - label=ready-to-merge
       - label!=hold-off-merging
-      - status-success=CI / build
     actions:
       merge:
         commit_message: title+body


### PR DESCRIPTION
This PR will change the merge strategy back to `merge` so that we get a lovely commit object in history to have a visual grouping of commits by PR. It also minimizes the config by leaning on defaults and the branch protections already enforced by GitHub. Finally, the last commit will ensure that all reviewers feedback have been addressed and not discarded by possibly unrelated approvals.