### PR TITLE
Change the negative label to pre-existing `do-not-merge`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "#commented-reviews-by=0"
       - label=ready-to-merge
-      - label!=hold-off-merging
+      - label!=do-not-merge
     actions:
       merge:
         commit_message: title+body


### PR DESCRIPTION
We already have `do-not-merge` and it feels more natural and maybe
easier to recall when looking to apply it.