### PR TITLE
Try out setting `strict_method: rebase`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,3 +11,4 @@ pull_request_rules:
       merge:
         commit_message: title+body
         strict: smart+fastpath
+        strict_method: rebase


### PR DESCRIPTION
This will have mergify rebase the PR on top of master instead of merging
master into the PR. The reason for this is to help keep history neater.
Merging master into the PR isn't too bad if the PR was relatively short
and started recently, but gets to be pretty bad the longer it lives or
the earlier it branched off of master.

The only real down side to this in our use case is that upon rebasing,
Mergify impersonates one of the repository members when doing the
rebase, so the history will reflect that as "commiter". I've chatted
with Mergify and this is actually on their roadmap and of high priority
so :fingers_crossed:.