### PR TITLE
Revert "Try out setting `strict_method: rebase`"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,4 +11,3 @@ pull_request_rules:
       merge:
         commit_message: title+body
         strict: smart+fastpath
-        strict_method: rebase


### PR DESCRIPTION
This reverts commit b2d1b4cc49e6a5abca49eb6d99f6fa4f26c6e139.

Might revist after some further experimentation/exploration with
Mergify. The way we have GitHub setup to dismiss reviews on pushes
automatically makes the dev experience almost as bad as if there was no
mergify at all. Mergify will happily rebase a PR but GitHub will block
merging. It would be nice to try out letting Mergify manage the "dismiss
reviews on code pushes" bit and see if it's smart enough to not dismiss
when it's doing it normal job.