### PR TITLE
Added the nix image version '2.3.4' in the .drone.yml file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -57,7 +57,7 @@ steps:
       - CGO_ENABLED=0 go test -v ./...
 
   - name: ci-checks
-    image: nixos/nix
+    image: nixos/nix:2.3.4
     commands:
       - ./ci-checks.sh
 


### PR DESCRIPTION
This fix the issue of ci-checks in CI while raising a PR