### PR TITLE
Pinned registry to 2.6

### DIFF
--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry:2
-RUN apk add --no-cache --update curl
+RUN apk add --no-cache --update curl apache2-utils
 ARG REGISTRY_USERNAME
 ARG REGISTRY_PASSWORD
 RUN mkdir -p /certs /auth

--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry:2
-RUN apk add --no-cache --update curl
+FROM registry:2.7
+RUN apk add --no-cache --update curl apache2-utils
 ARG REGISTRY_USERNAME
 ARG REGISTRY_PASSWORD
 RUN mkdir -p /certs /auth

--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry:2.7
-RUN apk add --no-cache --update curl apache2-utils
+FROM registry:2
+RUN apk add --no-cache --update curl
 ARG REGISTRY_USERNAME
 ARG REGISTRY_PASSWORD
 RUN mkdir -p /certs /auth

--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry:2
-RUN apk add --no-cache --update curl apache2-utils
+FROM registry:2.6.2
+RUN apk add --no-cache --update curl
 ARG REGISTRY_USERNAME
 ARG REGISTRY_PASSWORD
 RUN mkdir -p /certs /auth


### PR DESCRIPTION
It looks like htpasswd was removed from the upstream registry image. Pinned to 2.7 and added apache2-utils.