### PR TITLE
Add the apache2-utils package to the registry Dockerfile

### DIFF
--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
-FROM registry:2.6.2
-RUN apk add --no-cache --update curl
+FROM registry:2.7.1
+RUN apk add --no-cache --update curl apache2-utils
 ARG REGISTRY_USERNAME
 ARG REGISTRY_PASSWORD
 RUN mkdir -p /certs /auth


### PR DESCRIPTION
## Title

Add the apache2-utils package to the registry Dockerfile #184

By adding apache2-utils we document the need for htpasswd and
mitigate against future breakages when upgrading images.

This is required due to an issue introduced where the latest
image on the Docker Hub removed the htpasswd utility.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Testing

```
space-mini:registry alex$ docker build --build-arg REGISTRY_USERNAME=alexellis --build-arg REGISTRY_PASSWORD=test1234 -t registry-local .
Sending build context to Docker daemon  2.048kB
Step 1/7 : FROM registry:2.7.1
 ---> 2d4f4b5309b1
Step 2/7 : RUN apk add --no-cache --update curl apache2-utils
 ---> Using cache
 ---> 71803a7766cd
Step 3/7 : ARG REGISTRY_USERNAME
 ---> Using cache
 ---> f5a374288696
Step 4/7 : ARG REGISTRY_PASSWORD
 ---> Using cache
 ---> e4bbba2f97c5
Step 5/7 : RUN mkdir -p /certs /auth
 ---> Running in 7298318ba058
Removing intermediate container 7298318ba058
 ---> 994ca00ce50b
Step 6/7 : RUN htpasswd -Bbn ${REGISTRY_USERNAME} ${REGISTRY_PASSWORD} > /auth/htpasswd
 ---> Running in 562ec374240c
Removing intermediate container 562ec374240c
 ---> e31f51cd0a44
Step 7/7 : EXPOSE 443
 ---> Running in 3cc6e2fdb524
Removing intermediate container 3cc6e2fdb524
 ---> b6ebdd33a11d
Successfully built b6ebdd33a11d
Successfully tagged registry-local:latest
```

This is a follow-up PR to #178 
