### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behaviour
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behaviour
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+
+* Operating System and version (e.g. Linux, Windows, MacOS):
+
+* Link to your project or a code example to reproduce issue:
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Description
+
+<!--- Please describe what this PR is going to change -->
+
+## Why is this needed
+
+<!--- Link to issue you have raised -->
+
+Fixes: #
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+
+## How are existing users impacted? What migration steps/scripts do we need?
+
+<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
+<!--- Requires a DB migration script, etc. -->
+
+
+## Checklist:
+
+I have:
+
+- [ ] updated the documentation and/or roadmap (if required)
+- [ ] added unit or e2e tests
+- [ ] provided instructions on how to upgrade


### PR DESCRIPTION
## Title

Add GitHub issue and PR templates

## Description

These GitHub templates aim to improve the level of detail on
pull requests and issues raised by the team, to make the
external community feel more welcome and part of the project.

These are copyright to OpenFaaS Ltd, but we are happy to
contribute them under the license of this project for use by
Packet / Tinkerbell.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>