### PR TITLE
Added 4G memory for worker to prevent OOM errors when booting OSIE

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -36,7 +36,7 @@ Vagrant.configure('2') do |config|
                       auto_config: false
 
     worker.vm.provider :libvirt do |lv|
-      lv.memory = 1*1024
+      lv.memory = 4*1024
       lv.cpus = 1
       lv.boot 'network'
       lv.mgmt_attach = false
@@ -44,7 +44,7 @@ Vagrant.configure('2') do |config|
 
     worker.vm.provider :virtualbox do |vb, worker|
       worker.vm.box = 'generic/alpine38'
-      vb.memory = 1*1024
+      vb.memory = 4*1024
       vb.cpus = 1
       vb.gui = true
       vb.customize [


### PR DESCRIPTION
Intended to address https://github.com/tinkerbell/tink/issues/181 by simply upping the amount of memory on the worker.