### PR TITLE
Fix for #192  added PV for postgres

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       POSTGRES_USER: tinkerbell
     volumes:
       - ./db/tinkerbell-init.sql:/docker-entrypoint-initdb.d/tinkerbell-init.sql:ro
+      - postgres_data:/var/lib/postgresql/data:rw
     ports:
       - 5432:5432
     healthcheck:
@@ -149,3 +150,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
Added persistent volume for postgres container in provisioner. 


**postgres data:** 

docker exec -i deploy_tink-cli_1 tink template list 
+--------------------------------------+---------------+-------------------------------+-------------------------------+
| TEMPLATE ID                          | TEMPLATE NAME | CREATED AT                    | UPDATED AT                    |
+--------------------------------------+---------------+-------------------------------+-------------------------------+
| 2d4cfe8a-5630-481a-89ff-b34dcabad795 | hello-world   | 2020-06-24 12:27:44 +0000 UTC | 2020-06-24 12:27:44 +0000 UTC |
+--------------------------------------+---------------+-------------------------------+-------------------------------+


**stopping and removing of container** 

vagrant@provisioner:/vagrant/deploy$ docker ps 
CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS                    PORTS                                  NAMES
f5196b56e446        postgres:10-alpine                   "docker-entrypoint.s…"   9 minutes ago       Up 9 minutes (healthy)    0.0.0.0:5432->5432/tcp                 deploy_db_1


vagrant@provisioner:/vagrant/deploy$ docker stop f5196b56e446 
f5196b56e446
vagrant@provisioner:/vagrant/deploy$ docker rm f5196b56e446
f5196b56e446

**restarting of container** 

vagrant@provisioner:/vagrant/deploy$ docker-compose up -d db 
WARNING: The TINKERBELL_TINK_USERNAME variable is not set. Defaulting to a blank string.
WARNING: The TINKERBELL_TINK_PASSWORD variable is not set. Defaulting to a blank string.
Creating deploy_db_1 ... done

**verifying data** 

vagrant@provisioner:/vagrant/deploy$ docker exec -i deploy_tink-cli_1 tink template list 
+--------------------------------------+---------------+-------------------------------+-------------------------------+
| TEMPLATE ID                          | TEMPLATE NAME | CREATED AT                    | UPDATED AT                    |
+--------------------------------------+---------------+-------------------------------+-------------------------------+
| 2d4cfe8a-5630-481a-89ff-b34dcabad795 | hello-world   | 2020-06-24 12:27:44 +0000 UTC | 2020-06-24 12:27:44 +0000 UTC |
+--------------------------------------+---------------+-------------------------------+-------------------------------+
