### PR TITLE
Fix issue #150: Modified the behaviour of few "tink hardware cli"

### DIFF
--- a/cmd/tink-cli/cmd/hardware/all.go
+++ b/cmd/tink-cli/cmd/hardware/all.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tinkerbell/tink/protos/hardware"
 )
 
-// listCmd represents the all command
+// listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "list all known hardware",
@@ -35,7 +35,7 @@ var listCmd = &cobra.Command{
 			}
 		}
 		if err != nil && err != io.EOF {
-			log.Println(err)
+			log.Fatal(err)
 		} else {
 			t.Render()
 		}

--- a/cmd/tink-cli/cmd/hardware/all.go
+++ b/cmd/tink-cli/cmd/hardware/all.go
@@ -2,41 +2,46 @@ package hardware
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 	"log"
+	"os"
 
+	"github.com/jedib0t/go-pretty/table"
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/hardware"
 )
 
-// allCmd represents the all command
-var allCmd = &cobra.Command{
-	Use:   "all",
-	Short: "get all known hardware for facility",
+// listCmd represents the all command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "list all known hardware",
 	Run: func(cmd *cobra.Command, args []string) {
-		alls, err := client.HardwareClient.All(context.Background(), &hardware.Empty{})
+
+		t := table.NewWriter()
+		t.SetOutputMirror(os.Stdout)
+		t.AppendHeader(table.Row{"ID", "MAC Address", "IP address", "Hostname"})
+
+		list, err := client.HardwareClient.All(context.Background(), &hardware.Empty{})
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		var hw *hardware.Hardware
 		err = nil
-		for hw, err = alls.Recv(); err == nil && hw != nil; hw, err = alls.Recv() {
-			b, err := json.Marshal(hw)
-			if err != nil {
-				log.Println(err)
+		for hw, err = list.Recv(); err == nil && hw != nil; hw, err = list.Recv() {
+			for _, iface := range hw.GetNetwork().GetInterfaces() {
+				t.AppendRow(table.Row{hw.Id, iface.Dhcp.Mac, iface.Dhcp.Ip.Address, iface.Dhcp.Hostname})
 			}
-			fmt.Println(string(b))
 		}
 		if err != nil && err != io.EOF {
 			log.Println(err)
+		} else {
+			t.Render()
 		}
 	},
 }
 
 func init() {
-	SubCommands = append(SubCommands, allCmd)
+	SubCommands = append(SubCommands, listCmd)
 }

--- a/cmd/tink-cli/cmd/hardware/commands.go
+++ b/cmd/tink-cli/cmd/hardware/commands.go
@@ -1,11 +1,16 @@
 package hardware
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
+	"os"
 
+	"github.com/jedib0t/go-pretty/table"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
+	"github.com/tinkerbell/tink/protos/hardware"
 )
 
 // SubCommands holds the sub commands for template command
@@ -22,4 +27,28 @@ func verifyUUIDs(args []string) error {
 		}
 	}
 	return nil
+}
+
+func printOutput(data bool, hw *hardware.Hardware, input string) {
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.AppendHeader(table.Row{"Field Name", "Value"})
+	if !data {
+		for _, iface := range hw.GetNetwork().GetInterfaces() {
+			if iface.Dhcp.Ip.Address == input || iface.Dhcp.Mac == input {
+				t.AppendRow(table.Row{"ID", hw.Id})
+				t.AppendRow(table.Row{"MAC Address", iface.Dhcp.Mac})
+				t.AppendRow(table.Row{"IP Address", iface.Dhcp.Ip.Address})
+				t.AppendRow(table.Row{"Hostname", iface.Dhcp.Hostname})
+			}
+		}
+		t.Render()
+	} else {
+		hwData, err := json.Marshal(hw)
+		if err != nil {
+			log.Println("Failed to marshal hardware data", err)
+		} else {
+			log.Println(string(hwData))
+		}
+	}
 }

--- a/cmd/tink-cli/cmd/hardware/commands.go
+++ b/cmd/tink-cli/cmd/hardware/commands.go
@@ -46,7 +46,7 @@ func printOutput(data bool, hw *hardware.Hardware, input string) {
 	} else {
 		hwData, err := json.Marshal(hw)
 		if err != nil {
-			log.Println("Failed to marshal hardware data", err)
+			log.Fatal("Failed to marshal hardware data", err)
 		} else {
 			log.Println(string(hwData))
 		}

--- a/cmd/tink-cli/cmd/hardware/ip.go
+++ b/cmd/tink-cli/cmd/hardware/ip.go
@@ -44,7 +44,7 @@ var ipCmd = &cobra.Command{
 
 func addIPFlags() {
 	flags := ipCmd.Flags()
-	flags.BoolVarP(&data, "details", "d", false, "Provide the complete hardware details in json format")
+	flags.BoolVarP(&data, "details", "d", false, "provide the complete hardware details in json format")
 }
 
 func init() {

--- a/cmd/tink-cli/cmd/hardware/ip.go
+++ b/cmd/tink-cli/cmd/hardware/ip.go
@@ -4,7 +4,6 @@ package hardware
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -13,6 +12,8 @@ import (
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/hardware"
 )
+
+var data bool
 
 // ipCmd represents the ip command
 var ipCmd = &cobra.Command{
@@ -33,15 +34,20 @@ var ipCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
-			b, err := json.Marshal(hw)
-			if err != nil {
-				log.Fatal(err)
+			if hw.GetId() == "" {
+				log.Fatal("IP address not found in the database ", ip)
 			}
-			fmt.Println(string(b))
+			printOutput(data, hw, ip)
 		}
 	},
 }
 
+func addIPFlags() {
+	flags := ipCmd.Flags()
+	flags.BoolVarP(&data, "details", "d", false, "Provide the complete hardware details in json format")
+}
+
 func init() {
+	addIPFlags()
 	SubCommands = append(SubCommands, ipCmd)
 }

--- a/cmd/tink-cli/cmd/hardware/mac.go
+++ b/cmd/tink-cli/cmd/hardware/mac.go
@@ -42,7 +42,7 @@ var macCmd = &cobra.Command{
 
 func addMacFlags() {
 	flags := macCmd.Flags()
-	flags.BoolVarP(&data, "details", "d", false, "Provide the complete hardware details in json format")
+	flags.BoolVarP(&data, "details", "d", false, "provide the complete hardware details in json format")
 }
 
 func init() {

--- a/cmd/tink-cli/cmd/hardware/mac.go
+++ b/cmd/tink-cli/cmd/hardware/mac.go
@@ -4,7 +4,6 @@ package hardware
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net"
@@ -33,15 +32,20 @@ var macCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal(err)
 			}
-			b, err := json.Marshal(hw)
-			if err != nil {
-				log.Fatal(err)
+			if hw.GetId() == "" {
+				log.Fatal("MAC address not found in the database ", mac)
 			}
-			fmt.Println(string(b))
+			printOutput(data, hw, mac)
 		}
 	},
 }
 
+func addMacFlags() {
+	flags := macCmd.Flags()
+	flags.BoolVarP(&data, "details", "d", false, "Provide the complete hardware details in json format")
+}
+
 func init() {
+	addMacFlags()
 	SubCommands = append(SubCommands, macCmd)
 }

--- a/cmd/tink-cli/cmd/hardware/push.go
+++ b/cmd/tink-cli/cmd/hardware/push.go
@@ -24,7 +24,7 @@ var (
 // pushCmd represents the push command
 var pushCmd = &cobra.Command{
 	Use:   "push",
-	Short: "push new hardware to tinkerbell",
+	Short: "push new hardware to tink",
 	Example: `cat /tmp/data.json | tink hardware push
 tink hardware push --file /tmp/data.json`,
 	PreRunE: func(c *cobra.Command, args []string) error {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -81,6 +81,7 @@ func SetupMetrics(facility string, logger log.Logger) {
 		{"method": "Ingest", "op": ""},
 		{"method": "Watch", "op": "get"},
 		{"method": "Watch", "op": "push"},
+		{"method": "Delete", "op": "delete"},
 	}
 	initCounterLabels(CacheErrors, labels)
 	initGaugeLabels(CacheInFlight, labels)


### PR DESCRIPTION
## Description
Following are the change in this commit
1. `tink hardware mac <mac address>` will provide only relevent information instead of complete hardware json
2. `tink hardware ip <ip address>` will provide only relevent information instead of complete hardware json
3. There will be a flag in both of the above clis (--details) or (-d)  which can be provided to get the complete hardware data
4. `tink hardware all` cli has been renamed to `tink hardware list`
5. The above cli will only list the relevent information (which is 'hardware-id', 'mac address', 'ip address' and 'hostname for now) instead of providing the complete json of all the hardware present in the database.

## Why is this needed

Fixes: #150 

## How Has This Been Tested?
I have tested this locally by pushing the hardware data for two different hardware using `tink hardware push` command and then try to run the clis mentioned in the above description.
Following are the output of the commands.
    1. tink hardware list 

```
+--------------------------------------+-------------------+-------------+-----------+
| ID                                   | MAC ADDRESS       | IP ADDRESS  | HOSTNAME  |
+--------------------------------------+-------------------+-------------+-----------+
| f9f56dff-098a-4c5f-a51c-19ad35de85d2 | 98:03:9b:89:d7:da | 192.168.1.4 | localhost |
| f9f56dff-098a-4c5f-a51c-19ad35de85d1 | 98:03:9b:89:d7:ba | 192.168.1.5 | worker_1 |
+--------------------------------------+-------------------+-------------+-----------+

```
With the help of above command you will get the list of hardware present in the database. Now you can run following commands:
 
2.
     a.  tink hardware mac 98:03:9b:89:d7:da

```
+-------------+--------------------------------------+
| FIELD NAME  | VALUE                                |
+-------------+--------------------------------------+
| ID          | f9f56dff-098a-4c5f-a51c-19ad35de85d2 |
| MAC Address | 98:03:9b:89:d7:da                    |
| IP Address  | 192.168.1.4                          |
| Hostname    | localhost                            |
+-------------+--------------------------------------+

```

    b.  tink hardware mac 98:03:9b:89:d7:da  -d ( provide -d flag )

`{"metadata":{"instance":{},"facility":{"facility_code":"onprem"}},"network":{"interfaces":[{"dhcp":{"mac":"98:03:9b:89:d7:da","hostname":"localhost","arch":"x86_64","ip":{"address":"192.168.1.4","netmask":"255.255.255.248","gateway":"192.168.1.1"}},"netboot":{"allow_pxe":true,"allow_workflow":true}}]},"id":"f9f56dff-098a-4c5f-a51c-19ad35de85d2"}`
        
3. Same thing will be applicable for `tink hardware ip`  command:
    a. tink hardware ip 192.168.1.4
```
+-------------+--------------------------------------+
| FIELD NAME  | VALUE                                |
+-------------+--------------------------------------+
| ID          | f9f56dff-098a-4c5f-a51c-19ad35de85d2 |
| MAC Address | 98:03:9b:89:d7:da                    |
| IP Address  | 192.168.1.4                          |
| Hostname    | localhost                            |
+-------------+--------------------------------------+

```

  b. tink hardware ip 192.168.1.4  -d ( provide -d flag )

`{"metadata":{"instance":{},"facility":{"facility_code":"onprem"}},"network":{"interfaces":[{"dhcp":{"mac":"98:03:9b:89:d7:da","hostname":"localhost","arch":"x86_64","ip":{"address":"192.168.1.4","netmask":"255.255.255.248","gateway":"192.168.1.1"}},"netboot":{"allow_pxe":true,"allow_workflow":true}}]},"id":"f9f56dff-098a-4c5f-a51c-19ad35de85d2"} `

4. And at last the output of tink hardware --help is look like as follows:

```
tink hardware client

Usage:
  tink hardware [command]

Examples:
tink hardware [command]

Available Commands:
  delete      delete hardware by id
  id          get hardware by id
  ip          get hardware by any associated ip
  list        list all known hardware
  mac         get hardware by any associated mac
  push        push new hardware to tink
  watch       register to watch an id for any changes

Flags:
  -h, --help   help for hardware

Global Flags:
  -f, --facility string   used to build grpc and http urls

Use "tink hardware [command] --help" for more information about a command.

```
## How are existing users impacted? What migration steps/scripts do we need?
There will be a change for existing user for `tink hardware`  as mentioned in the description. There is no need of migration steps or scripts.
