### PR TITLE
#206 fixed HW tinkerbell client name

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -68,8 +68,8 @@ func Setup() {
 	HardwareClient = hardware.NewHardwareServiceClient(conn)
 }
 
-// NewTinkerbellClient creates a new hardware client
-func NewTinkerbellClient() (hardware.HardwareServiceClient, error) {
+// TinkerbellHWClient creates a new hardware client
+func TinkerbellHWClient() (hardware.HardwareServiceClient, error) {
 	conn, err := GetConnection()
 	if err != nil {
 		log.Fatal(err)

--- a/client/main.go
+++ b/client/main.go
@@ -68,8 +68,8 @@ func Setup() {
 	HardwareClient = hardware.NewHardwareServiceClient(conn)
 }
 
-// TinkerbellHWClient creates a new hardware client
-func TinkerbellHWClient() (hardware.HardwareServiceClient, error) {
+// TinkHardwareClient creates a new hardware client
+func TinkHardwareClient() (hardware.HardwareServiceClient, error) {
 	conn, err := GetConnection()
 	if err != nil {
 		log.Fatal(err)
@@ -77,8 +77,8 @@ func TinkerbellHWClient() (hardware.HardwareServiceClient, error) {
 	return hardware.NewHardwareServiceClient(conn), nil
 }
 
-// TinkerbellWorkflowClient creates a new workflow clients
-func TinkerbellWorkflowClient() (workflow.WorkflowSvcClient, error) {
+// TinkWorkflowClient creates a new workflow client
+func TinkWorkflowClient() (workflow.WorkflowSvcClient, error) {
 	conn, err := GetConnection()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## Description

Changed the name of tinkerbell Hardware client 

## Why is this needed

name of client should be specific to type of service.

Fixes: #

changed the name of the client 

## How Has This Been Tested?

Testing was completed by bringing worker up. Changes were also done for hegel and boots. 



![image](https://user-images.githubusercontent.com/13061957/86789464-f4976500-c084-11ea-937f-3bc4aa58429e.png)
