### PR TITLE
#260 modified tink client name and desc

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -68,8 +68,8 @@ func Setup() {
 	HardwareClient = hardware.NewHardwareServiceClient(conn)
 }
 
-// NewTinkerbellClient creates a new hardware client
-func NewTinkerbellClient() (hardware.HardwareServiceClient, error) {
+// TinkHardwareClient creates a new hardware client
+func TinkHardwareClient() (hardware.HardwareServiceClient, error) {
 	conn, err := GetConnection()
 	if err != nil {
 		log.Fatal(err)
@@ -77,8 +77,8 @@ func NewTinkerbellClient() (hardware.HardwareServiceClient, error) {
 	return hardware.NewHardwareServiceClient(conn), nil
 }
 
-// TinkerbellWorkflowClient creates a new workflow clients
-func TinkerbellWorkflowClient() (workflow.WorkflowSvcClient, error) {
+// TinkWorkflowClient creates a new workflow client
+func TinkWorkflowClient() (workflow.WorkflowSvcClient, error) {
 	conn, err := GetConnection()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Description
Changed the name of tinkerbell Hardware client

Why is this needed
name of client should be specific to type of service.

Fixes: #

changed the name of the client

How Has This Been Tested?
Testing was completed by bringing worker up. Changes were also done for hegel and boots.

![image](https://user-images.githubusercontent.com/13061957/86890774-73d77800-c11b-11ea-9f3f-fece5b6f170f.png)

