### PR TITLE
Update generate-envrc.sh

### DIFF
--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -47,6 +47,8 @@ generate_envrc() (
 
 	validate_tinkerbell_network_interface "$tink_interface"
 
+        local tink_password
+        tink_password=$(generate_password)
 	local registry_password
 	registry_password=$(generate_password)
 	cat <<EOF
@@ -67,6 +69,10 @@ export TINKERBELL_HOST_IP=192.168.1.1
 
 # NGINX IP is used by provisioner to serve files required for iPXE boot
 export TINKERBELL_NGINX_IP=192.168.1.2
+
+# Tink server username and password
+export TINKERBELL_TINK_USERNAME=admin
+export TINKERBELL_TINK_PASSWORD="$tink_password"
 
 # Docker Registry's username and password
 export TINKERBELL_REGISTRY_USERNAME=admin

--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -47,8 +47,8 @@ generate_envrc() (
 
 	validate_tinkerbell_network_interface "$tink_interface"
 
-        local tink_password
-        tink_password=$(generate_password)
+	local tink_password
+	tink_password=$(generate_password)
 	local registry_password
 	registry_password=$(generate_password)
 	cat <<EOF


### PR DESCRIPTION
Executing setup.sh does warning ...

WARNING: The TINKERBELL_TINK_PASSWORD variable is not set. Defaulting to a blank string.
WARNING: The TINKERBELL_TINK_USERNAME variable is not set. Defaulting to a blank string.

Doesn't generate-envrc.sh create these settings?
Doing a grep inside the tink repo root does.

root@deblnxsrv2:/var/tinkerbell/tink# grep -r TINKERBELL_TINK

deploy/docker-compose.yml: TINK_AUTH_USERNAME: ${TINKERBELL_TINK_USERNAME}
deploy/docker-compose.yml: TINK_AUTH_PASSWORD: ${TINKERBELL_TINK_PASSWORD}