### PR TITLE
chore: gitignore files generated during vagrant provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ terraform.tfstate.backup
 
 # Vagrant
 **/.vagrant
+envrc
+deploy/state


### PR DESCRIPTION
## Description

There are two files generated by the `setup.sh` script that are annoying
during a vagrant provisioning because there are not ignored by git:

* `envrc` is the file we use to make `setup.sh` idempotent and
  configurable. It gets generated first time and reused during
  `setup.sh`.

* `deploy/state` contains files such as certs or cache files that are
  relevant for your current provisioning.

## Why is this needed

It helps to avoid the mistake of pushing useless files.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
