### PR TITLE
chore: expose tink server via Vagrant port forward

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -14,6 +14,10 @@ Vagrant.configure('2') do |config|
                         libvirt__forward_mode: 'none',
                         auto_config: false
 
+    provisioner.vm.network "forwarded_port", guest: 42113, host: 42113
+    provisioner.vm.network "forwarded_port", guest: 42114, host: 42114
+
+
     provisioner.vm.provider :libvirt do |lv, override|
       lv.memory = 2*1024
       lv.cpus = 2


### PR DESCRIPTION
## Description

I am working at the e2e test for the vagrant setup. It is very useful to
be able to reach tink-server from outside the VM because that where the
logic that asserts the right execution lives.

It is also good for experimentation because I was able to build the tink
cli:

```
go build -o tink ./cmd/tink-cli/main.go
```

I was able to use the tink cli from my local environment. Way more
familiar that `docker exec` as a workflow imho:

```
$ TINKERBELL_GRPC_AUTHORITY=127.0.0.1:42113 TINKERBELL_CERT_URL=http://127.0.0.1:42114/cert ./tink hardware list
+----+-------------+------------+----------+
| ID | MAC ADDRESS | IP ADDRESS | HOSTNAME |
+----+-------------+------------+----------+
+----+-------------+------------+----------+
```

## Why is this needed

it is more friendly to use and it helps me writing e2e tests #169 