### PR TITLE
Disable tk client setup  if an --help flag is present

### DIFF
--- a/cmd/tink-cli/cmd/root.go
+++ b/cmd/tink-cli/cmd/root.go
@@ -33,7 +33,12 @@ func Execute() error {
 }
 
 func isHelpCommand() bool {
-	return len(os.Args) == 1 || (len(os.Args) == 2 && (os.Args[1] == "-h" || os.Args[1] == "--help"))
+	for _, arg := range os.Args {
+		if arg == "-h" || arg == "--help" {
+			return true
+		}
+	}
+	return false
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION

## Description

An up and running Tinkerbell Server should not be a requirement for the
`help` command to work.

This is a bit tricky because our client is globally instantiated as part
of the root command.

I made it to work for:


Previously the command returned `2020/06/08 11:16:25 undefined
TINKERBELL_CERT_URL`. Now it returns the help command.


## Why is this needed

Fixed #164 

## How Has This Been Tested?

Run command:

```
$ ./cmd/tink-cli/tink-cli workflow --help
```


## How are existing users impacted? What migration steps/scripts do we need?

They will get as output the helper of the command and not an error.
