### PR TITLE
Move to GitHub action from Drone

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,104 @@
+name: For each commit and PR
+on:
+  push:
+  pull_request:
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.14.6'
+    - name: go fmt
+      run: go fmt ./...
+    - name: go vet
+      run: go vet ./...
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v1
+      with:
+        version: v1.30
+    - name: go vet
+      run: go test ./...
+    - name: Build binaries
+      run: make
+    - name: Upload tink-server binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: tink-server
+        path: ./cmd/tink-server/tink-server
+    - name: Upload tink-cli binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: tink-cli
+        path: ./cmd/tink-cli/tink-cli
+    - name: Upload tink-worker binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: tink-worker
+        path: ./cmd/tink-worker/tink-worker
+    - uses: cachix/install-nix-action@v10
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: ./ci-checks.sh
+  docker-images:
+    env:
+      CGO_ENABLED: 0
+    runs-on: ubuntu-latest
+    needs: [validation]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Download tink-cli binary
+      uses: actions/download-artifact@v2
+      with:
+        name: tink-cli
+        path: ./cmd/tink-cli/tink-cli
+    - name: Download tink-server binary
+      uses: actions/download-artifact@v2
+      with:
+        name: tink-server
+        path: ./cmd/tink-server/tink-server
+    - name: Download tink-worker binary
+      uses: actions/download-artifact@v2
+      with:
+        name: tink-worker
+        path: ./cmd/tink-worker/tink-worker
+    - name: quay.io/tinkerbell/tink
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        repository: tinkerbell/tink
+        path: ./cmd/tink-server/
+        registry: quay.io
+        push: ${{ startsWith(github.ref, 'refs/heads/master') }}
+        tags: latest
+        tag_with_sha: true
+    - name: quay.io/tinkerbell/tink-cli
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        repository: tinkerbell/tink-cli
+        path: ./cmd/tink-cli/
+        registry: quay.io
+        push: ${{ startsWith(github.ref, 'refs/heads/master') }}
+        tags: latest
+        tag_with_sha: true
+    - name: quay.io/tinkerbell/tink-worker
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        repository: tinkerbell/tink-worker
+        path: ./cmd/tink-worker/
+        registry: quay.io
+        push: ${{ startsWith(github.ref, 'refs/heads/master') }}
+        tags: latest
+        tag_with_sha: true


### PR DESCRIPTION
## Description

Move from Drone to Github Action

## Why is this needed

Fixes: #233 

## How Has This Been Tested?

I am using `act` to run GitHub Action locally.

## How are existing users impacted? What migration steps/scripts do we need?

none

- [x] go fmt
- [x] go vet
- [x] golang-ci
- [x] go test
- [x] It runs the ci-check script
- [x] build docker image tink-cli
- [x] build docker image tink-worker
- [x] build docker image tink-server

When merged to master:

- [x] push docker image tink-cli
- [x] push docker image tink-worker
- [x] push docker image tink-server
