### PR TITLE
fix go vet

### DIFF
--- a/db/workflow.go
+++ b/db/workflow.go
@@ -132,7 +132,7 @@ func insertActionList(ctx context.Context, db *sql.DB, yamlData string, id uuid.
 	if err != nil {
 		return errors.Wrap(err, "Invalid Template")
 	}
-	var actionList []pb.WorkflowAction
+	var actionList []*pb.WorkflowAction
 	var uniqueWorkerID uuid.UUID
 	for _, task := range wfymldata.Tasks {
 		taskEnvs := map[string]string{}
@@ -203,7 +203,7 @@ func insertActionList(ctx context.Context, db *sql.DB, yamlData string, id uuid.
 				Environment: envs,
 				Volumes:     ac.Volumes,
 			}
-			actionList = append(actionList, action)
+			actionList = append(actionList, &action)
 		}
 	}
 	totalActions := int64(len(actionList))
@@ -637,7 +637,7 @@ func InsertIntoWorkflowEventTable(ctx context.Context, db *sql.DB, wfEvent *pb.W
 }
 
 // ShowWorkflowEvents returns all workflows
-func ShowWorkflowEvents(db *sql.DB, wfID string, fn func(wfs pb.WorkflowActionStatus) error) error {
+func ShowWorkflowEvents(db *sql.DB, wfID string, fn func(wfs *pb.WorkflowActionStatus) error) error {
 	rows, err := db.Query(`
        SELECT worker_id, task_name, action_name, execution_time, message, status, created_at
 	   FROM workflow_event
@@ -667,7 +667,7 @@ func ShowWorkflowEvents(db *sql.DB, wfID string, fn func(wfs pb.WorkflowActionSt
 			return err
 		}
 		createdAt, _ := ptypes.TimestampProto(evTime)
-		wfs := pb.WorkflowActionStatus{
+		wfs := &pb.WorkflowActionStatus{
 			WorkerId:     id,
 			TaskName:     tName,
 			ActionName:   aName,

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -241,7 +241,7 @@ func (s *server) ShowWorkflowEvents(req *workflow.GetRequest, stream workflow.Wo
 
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
-	err := db.ShowWorkflowEvents(s.db, req.Id, func(w workflowpb.WorkflowActionStatus) error {
+	err := db.ShowWorkflowEvents(s.db, req.Id, func(w *workflowpb.WorkflowActionStatus) error {
 		wfs := &workflow.WorkflowActionStatus{
 			WorkerId:     w.WorkerId,
 			TaskName:     w.TaskName,


### PR DESCRIPTION
```console
$ go vet ./...
# github.com/tinkerbell/tink/db
db/workflow.go:206:36: call of append copies lock value: github.com/tinkerbell/tink/protos/workflow.WorkflowAction contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
db/workflow.go:679:12: call of fn copies lock value: github.com/tinkerbell/tink/protos/workflow.WorkflowActionStatus contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
# github.com/tinkerbell/tink/grpc-server
grpc-server/workflow.go:244:52: func passes lock by value: github.com/tinkerbell/tink/protos/workflow.WorkflowActionStatus contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
```