### PR TITLE
add ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,37 @@
+# Roadmap
+
+This document provides a high level roadmap for Tinkerbell development and
+upcoming releases. Community and contributor involvement is vital for the
+success of implementing the desired items for each release. We hope that the
+items listed below inspire engagement from the community to keeping Tinkerbell
+progressing and shipping exciting and valuable features.
+
+_The format below is `[version - theme](milestone link)`._
+
+## [v0.1 - Public Debut](https://github.com/tinkerbell/tink/releases/tag/v0.1.0)
+
+* (tba)
+
+## [v0.2 - Installers](https://github.com/tinkerbell/tink/releases/tag/v0.1.0)
+
+* (tba)
+
+## Future
+
+This items listed below can be used to get a general idea of the features that
+are important to the community and what we are planning. We use the
+[milestone](https://github.com/tinkerbell/tink/milestones) feature in Github, so
+look there for the most up-to-date and issue plan.
+
+Each roadmap item should link to open issues or
+[proposals](https://github.com/tinkerbell/proposals) that describe the feature
+and set forth a plan.
+
+Pull requests that fulfill or expand the roadmap should include a separate
+commit updating this file. Acknowledging roadmap updates is part of the [pull
+request
+checklist](https://github.com/tinkerbell/.github/blob/master/PULL_REQUEST_TEMPLATE.md#checklist).
+
+_The items listed below do not represent a timeline of commitments._
+
+* (tba)


### PR DESCRIPTION
## Description

Adds an empty ROADMAP.md to reflect current direction and planning
efforts in the Tinkerbell ecosystem.

_I don't mind if this PR is closed in favor of another solution, I'm using this as a straw-man proposal._

Questions:

* We have 0.1.0 and 0.2.0 in the Milestones, but we don't have tags representing these releases.  Should we backfill the GH milestone pages? Backfill the roadmap included this PR? What happened in those milestones?
* Are we ok with using GH milestones and a roadmap.md file? It may seem like this is duplicating effort.  The roadmap can reflect in one sentence ideas that don't have working proposals and open issues.  This may also be a feature of GH Milestones.
* Each tinkerbell/* repository has a pull request checklist that asks if the roadmap was updated. Should each repository have a unique roadmap? Do we want issues raised in another repository to be followed-up with pull requests updating this repository's central roadmap?



<!--- Please describe what this PR is going to change -->

## Why is this needed

The pull request issue template refers to the roadmap.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
