### PR TITLE
fix binary permission during ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,12 @@ jobs:
       with:
         name: tink-worker
         path: ./cmd/tink-worker/tink-worker
+    - name: set tink-worker permission
+      run: chmod +x  ./cmd/tink-worker/tink-worker
+    - name: set tink-cli permission
+      run: chmod +x  ./cmd/tink-cli/tink-cli
+    - name: set tink-server permission
+      run: chmod +x  ./cmd/tink-server/tink-server
     - name: quay.io/tinkerbell/tink
       uses: docker/build-push-action@v1
       with:


### PR DESCRIPTION
We have to set binary permission otherwise this information gets lost
when moving from the go build job to docker image build in GitHub CI.

https://github.com/actions/download-artifact#permission-loss
