### PR TITLE
Unit tests for workflow RPC service

### DIFF
--- a/db/mock/workflow.go
+++ b/db/mock/workflow.go
@@ -2,11 +2,19 @@ package mock
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/tinkerbell/tink/db"
 	pb "github.com/tinkerbell/tink/protos/workflow"
+)
+
+const (
+	workflowWithNoData = "5a6d7564-d699-4e9f-a29c-a5890ccbd768"
+	workflowWithData   = "5711afcf-ea0b-4055-b4d6-9f88080f7afc"
+	workerWithWorkflow = "20fd5833-118f-4115-bd7b-1cf94d0f5727"
+	workerForErrCases  = "b6e1a7ba-3a68-4695-9846-c5fb1eee8bee"
 )
 
 // CreateWorkflow creates a new workflow
@@ -21,7 +29,7 @@ func (d DB) InsertIntoWfDataTable(ctx context.Context, req *pb.UpdateWorkflowDat
 
 // GetfromWfDataTable : Give you the ephemeral data from workflow_data table
 func (d DB) GetfromWfDataTable(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error) {
-	if req.WorkflowID == "5711afcf-ea0b-4055-b4d6-9f88080f7afc" {
+	if req.WorkflowID == workflowWithData {
 		return []byte("{'os': 'ubuntu', 'base_url': 'http://192.168.1.1/'}"), nil
 	}
 	return []byte{}, nil
@@ -39,7 +47,12 @@ func (d DB) GetWorkflowDataVersion(ctx context.Context, workflowID string) (int3
 
 // GetWorkflowsForWorker : returns the list of workflows for a particular worker
 func (d DB) GetWorkflowsForWorker(id string) ([]string, error) {
-	return []string{}, nil
+	if id == workerWithWorkflow {
+		return []string{workflowWithNoData, workflowWithData}, nil
+	} else if id == workerForErrCases {
+		return nil, errors.New("SELECT from worflow_worker_map")
+	}
+	return nil, nil
 }
 
 // GetWorkflow returns a workflow
@@ -69,6 +82,28 @@ func (d DB) UpdateWorkflowState(ctx context.Context, wfContext *pb.WorkflowConte
 
 // GetWorkflowContexts : gives you the current workflow context
 func (d DB) GetWorkflowContexts(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
+	if wfID == workflowWithData {
+		return &pb.WorkflowContext{
+			WorkflowId:           workflowWithData,
+			TotalNumberOfActions: 2,
+			CurrentAction:        "first_action",
+			CurrentActionIndex:   1,
+			CurrentActionState:   pb.ActionState_ACTION_PENDING,
+			CurrentTask:          "first_task",
+			CurrentWorker:        workerWithWorkflow,
+		}, nil
+	}
+	if wfID == workflowWithNoData {
+		return &pb.WorkflowContext{
+			WorkflowId:           workflowWithNoData,
+			TotalNumberOfActions: 3,
+			CurrentAction:        "second_action",
+			CurrentActionIndex:   3,
+			CurrentActionState:   pb.ActionState_ACTION_PENDING,
+			CurrentTask:          "second_task",
+			CurrentWorker:        workerWithWorkflow,
+		}, nil
+	}
 	return nil, nil
 }
 

--- a/db/mock/workflow.go
+++ b/db/mock/workflow.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	invalidID          = "d699-4e9f-a29c-a5890ccbd"
+	workflowForErr     = "1effe50d-3f21-4083-afa4-0e1620087d99"
 	firstWorkflowID    = "5a6d7564-d699-4e9f-a29c-a5890ccbd768"
 	secondWorkflowID   = "5711afcf-ea0b-4055-b4d6-9f88080f7afc"
 	workerWithWorkflow = "20fd5833-118f-4115-bd7b-1cf94d0f5727"
@@ -32,6 +33,9 @@ func (d DB) CreateWorkflow(ctx context.Context, wf db.Workflow, data string, id 
 
 // InsertIntoWfDataTable : Insert ephemeral data in workflow_data table
 func (d DB) InsertIntoWfDataTable(ctx context.Context, req *pb.UpdateWorkflowDataRequest) error {
+	if req.WorkflowID == workflowForErr {
+		return errors.New("INSERT Into workflow_data")
+	}
 	return nil
 }
 

--- a/db/workflow.go
+++ b/db/workflow.go
@@ -328,7 +328,7 @@ func (d TinkDB) GetWorkflowMetadata(ctx context.Context, req *pb.GetWorkflowData
 	}
 
 	if err != sql.ErrNoRows {
-		err = errors.Wrap(err, "SELECT")
+		err = errors.Wrap(err, "SELECT from workflow_data")
 		logger.Error(err)
 	}
 

--- a/grpc-server/tinkerbell.go
+++ b/grpc-server/tinkerbell.go
@@ -51,17 +51,21 @@ func (s *server) GetWorkflowContextList(context context.Context, req *pb.Workflo
 	if err != nil {
 		return nil, err
 	}
-	wfContexts := []*pb.WorkflowContext{}
-	for _, wf := range wfs {
-		wfContext, err := s.db.GetWorkflowContexts(context, wf)
-		if err != nil {
-			return nil, status.Errorf(codes.Aborted, err.Error())
+
+	if wfs != nil {
+		wfContexts := []*pb.WorkflowContext{}
+		for _, wf := range wfs {
+			wfContext, err := s.db.GetWorkflowContexts(context, wf)
+			if err != nil {
+				return nil, status.Errorf(codes.Aborted, err.Error())
+			}
+			wfContexts = append(wfContexts, wfContext)
 		}
-		wfContexts = append(wfContexts, wfContext)
+		return &pb.WorkflowContextList{
+			WorkflowContexts: wfContexts,
+		}, nil
 	}
-	return &pb.WorkflowContextList{
-		WorkflowContexts: wfContexts,
-	}, nil
+	return nil, nil
 }
 
 // GetWorkflowActions implements tinkerbell.GetWorkflowActions

--- a/grpc-server/tinkerbell_test.go
+++ b/grpc-server/tinkerbell_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/packethost/pkg/log"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tinkerbell/tink/db/mock"
@@ -13,11 +14,14 @@ import (
 
 const (
 	invalidID            = "d699-4e9f-a29c-a5890ccbd"
-	workflowWithNoData   = "5a6d7564-d699-4e9f-a29c-a5890ccbd768"
-	workflowWithData     = "5711afcf-ea0b-4055-b4d6-9f88080f7afc"
+	firstWorkflowID      = "5a6d7564-d699-4e9f-a29c-a5890ccbd768"
+	secondWorkflowID     = "5711afcf-ea0b-4055-b4d6-9f88080f7afc"
 	workerWithNoWorkflow = "4ebf0efa-b913-45a1-a9bf-c59829cb53a9"
 	workerWithWorkflow   = "20fd5833-118f-4115-bd7b-1cf94d0f5727"
 	workerForErrCases    = "b6e1a7ba-3a68-4695-9846-c5fb1eee8bee"
+	firstActionName      = "disk-wipe"
+	secondActionName     = "install-rootfs"
+	taskName             = "ubuntu-provisioning"
 )
 
 var testServer = &server{
@@ -25,6 +29,13 @@ var testServer = &server{
 }
 
 func TestMain(m *testing.M) {
+	os.Setenv("PACKET_ENV", "test")
+	os.Setenv("PACKET_VERSION", "ignored")
+	os.Setenv("ROLLBAR_TOKEN", "ignored")
+
+	l, _, _ := log.Init("github.com/tinkerbell/tink")
+	logger = l.Package("grpcserver")
+
 	os.Exit(m.Run())
 }
 
@@ -62,24 +73,21 @@ func TestGetWorkflowContextList(t *testing.T) {
 				assert.Nil(t, res)
 				return
 			}
-
 			assert.NoError(t, err)
 			if test.workerID == workerWithNoWorkflow {
 				assert.Nil(t, res)
 				return
 			}
-
 			assert.NotNil(t, res)
 			assert.Len(t, res.WorkflowContexts, 2)
 		})
 	}
 }
 
-func TestGetWorkflowsForWorker(t *testing.T) {
+func TestGetWorkflowActions(t *testing.T) {
 	testCases := []struct {
 		name          string
-		workerID      string
-		res           []string
+		workflowID    string
 		expectedError bool
 	}{
 		{
@@ -87,26 +95,110 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:     "no workflows found",
-			workerID: workerWithNoWorkflow,
+			name:          "invalid  workflow id",
+			workflowID:    invalidID,
+			expectedError: true,
 		},
 		{
-			name:     "workflows found for worker",
-			workerID: workerWithWorkflow,
-			res:      []string{workflowWithNoData, workflowWithData},
+			name:       "getting actions",
+			workflowID: secondWorkflowID,
 		},
 	}
-
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			res, err := getWorkflowsForWorker(testServer.db, test.workerID)
+			res, err := testServer.GetWorkflowActions(
+				context.TODO(), &pb.WorkflowActionsRequest{WorkflowId: test.workflowID},
+			)
 			if err != nil && test.expectedError {
 				assert.Error(t, err)
 				assert.Nil(t, res)
 				return
 			}
 			assert.NoError(t, err)
-			assert.Equal(t, test.res, res)
+			assert.NotNil(t, res)
+			assert.Len(t, res.ActionList, 1)
+			assert.Len(t, res.ActionList[0].Volumes, 3)
+			assert.Equal(t, res.ActionList[0].Name, secondActionName)
+		})
+	}
+}
+
+func TestReportActionStatus(t *testing.T) {
+	type req struct {
+		workflowID, taskName, actionName, workerID string
+		actionState                                pb.ActionState
+	}
+	testCases := []struct {
+		req
+		name          string
+		expectedError bool
+	}{
+		{
+			name:          "empty workflow id",
+			expectedError: true,
+			req: req{
+				taskName:   taskName,
+				actionName: firstActionName,
+			},
+		},
+		{
+			name:          "empty task name",
+			expectedError: true,
+			req: req{
+				workflowID: firstWorkflowID,
+				actionName: firstActionName,
+			},
+		},
+		{
+			name:          "empty action name",
+			expectedError: true,
+			req: req{
+				workflowID: firstWorkflowID,
+				taskName:   taskName,
+			},
+		},
+		{
+			name:          "error fetching workflow context",
+			expectedError: true,
+			req: req{
+				workflowID:  invalidID,
+				workerID:    workerWithWorkflow,
+				taskName:    taskName,
+				actionName:  firstActionName,
+				actionState: pb.ActionState_ACTION_PENDING,
+			},
+		},
+		{
+			name: "fetch workflow context",
+			req: req{
+				workflowID:  firstWorkflowID,
+				workerID:    workerWithWorkflow,
+				taskName:    taskName,
+				actionName:  secondActionName,
+				actionState: pb.ActionState_ACTION_IN_PROGRESS,
+			},
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := testServer.ReportActionStatus(context.TODO(),
+				&pb.WorkflowActionStatus{
+					WorkflowId:   test.req.workflowID,
+					ActionName:   test.req.actionName,
+					TaskName:     test.req.taskName,
+					WorkerId:     test.req.workerID,
+					ActionStatus: test.req.actionState,
+					Seconds:      0,
+				},
+			)
+
+			if err != nil && test.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, res)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, res)
 		})
 	}
 }
@@ -132,13 +224,13 @@ func TestGetWorkflowData(t *testing.T) {
 		},
 		{
 			name:          "workflow id with no data",
-			req:           &pb.GetWorkflowDataRequest{WorkflowID: workflowWithNoData},
+			req:           &pb.GetWorkflowDataRequest{WorkflowID: secondWorkflowID},
 			data:          []byte{},
 			expectedError: false,
 		},
 		{
 			name:          "workflow id with data",
-			req:           &pb.GetWorkflowDataRequest{WorkflowID: workflowWithData},
+			req:           &pb.GetWorkflowDataRequest{WorkflowID: firstWorkflowID},
 			data:          []byte("{'os': 'ubuntu', 'base_url': 'http://192.168.1.1/'}"),
 			expectedError: false,
 		},
@@ -156,6 +248,42 @@ func TestGetWorkflowData(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, res.Data)
 			assert.Equal(t, test.data, res.Data)
+		})
+	}
+}
+
+func TestGetWorkflowsForWorker(t *testing.T) {
+	testCases := []struct {
+		name          string
+		workerID      string
+		res           []string
+		expectedError bool
+	}{
+		{
+			name:          "empty workflow id",
+			expectedError: true,
+		},
+		{
+			name:     "no workflows found",
+			workerID: workerWithNoWorkflow,
+		},
+		{
+			name:     "workflows found for worker",
+			workerID: workerWithWorkflow,
+			res:      []string{firstWorkflowID, secondWorkflowID},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := getWorkflowsForWorker(testServer.db, test.workerID)
+			if err != nil && test.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, res)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.res, res)
 		})
 	}
 }

--- a/grpc-server/tinkerbell_test.go
+++ b/grpc-server/tinkerbell_test.go
@@ -1,0 +1,161 @@
+package grpcserver
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tinkerbell/tink/db/mock"
+	pb "github.com/tinkerbell/tink/protos/workflow"
+)
+
+const (
+	invalidID            = "d699-4e9f-a29c-a5890ccbd"
+	workflowWithNoData   = "5a6d7564-d699-4e9f-a29c-a5890ccbd768"
+	workflowWithData     = "5711afcf-ea0b-4055-b4d6-9f88080f7afc"
+	workerWithNoWorkflow = "4ebf0efa-b913-45a1-a9bf-c59829cb53a9"
+	workerWithWorkflow   = "20fd5833-118f-4115-bd7b-1cf94d0f5727"
+	workerForErrCases    = "b6e1a7ba-3a68-4695-9846-c5fb1eee8bee"
+)
+
+var testServer = &server{
+	db: mock.DB{},
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+func TestGetWorkflowContextList(t *testing.T) {
+	testCases := []struct {
+		name          string
+		workerID      string
+		expectedError bool
+	}{
+		{
+			name:          "empty workflow id",
+			expectedError: true,
+		},
+		{
+			name:          "database failure",
+			expectedError: true,
+			workerID:      workerForErrCases,
+		},
+		{
+			name:     "no workflows found",
+			workerID: workerWithNoWorkflow,
+		},
+		{
+			name:     "workflows found for worker",
+			workerID: workerWithWorkflow,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := testServer.GetWorkflowContextList(
+				context.TODO(), &pb.WorkflowContextRequest{WorkerId: test.workerID},
+			)
+			if err != nil && test.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, res)
+				return
+			}
+
+			assert.NoError(t, err)
+			if test.workerID == workerWithNoWorkflow {
+				assert.Nil(t, res)
+				return
+			}
+
+			assert.NotNil(t, res)
+			assert.Len(t, res.WorkflowContexts, 2)
+		})
+	}
+}
+
+func TestGetWorkflowsForWorker(t *testing.T) {
+	testCases := []struct {
+		name          string
+		workerID      string
+		res           []string
+		expectedError bool
+	}{
+		{
+			name:          "empty workflow id",
+			expectedError: true,
+		},
+		{
+			name:     "no workflows found",
+			workerID: workerWithNoWorkflow,
+		},
+		{
+			name:     "workflows found for worker",
+			workerID: workerWithWorkflow,
+			res:      []string{workflowWithNoData, workflowWithData},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := getWorkflowsForWorker(testServer.db, test.workerID)
+			if err != nil && test.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, res)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.res, res)
+		})
+	}
+}
+
+func TestGetWorkflowData(t *testing.T) {
+	testCases := []struct {
+		name          string
+		req           *pb.GetWorkflowDataRequest
+		data          []byte
+		expectedError bool
+	}{
+		{
+			name:          "empty workflow id",
+			req:           &pb.GetWorkflowDataRequest{WorkflowID: ""},
+			data:          []byte{},
+			expectedError: true,
+		},
+		{
+			name:          "invalid  workflow id",
+			req:           &pb.GetWorkflowDataRequest{WorkflowID: invalidID},
+			data:          []byte{},
+			expectedError: true,
+		},
+		{
+			name:          "workflow id with no data",
+			req:           &pb.GetWorkflowDataRequest{WorkflowID: workflowWithNoData},
+			data:          []byte{},
+			expectedError: false,
+		},
+		{
+			name:          "workflow id with data",
+			req:           &pb.GetWorkflowDataRequest{WorkflowID: workflowWithData},
+			data:          []byte("{'os': 'ubuntu', 'base_url': 'http://192.168.1.1/'}"),
+			expectedError: false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			res, err := testServer.GetWorkflowData(context.TODO(), test.req)
+
+			if err != nil && test.expectedError {
+				assert.Error(t, err)
+				assert.Equal(t, test.data, res.Data)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, res.Data)
+			assert.Equal(t, test.data, res.Data)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Added tests for the workflow RPC calls

## Why is this needed
Unit tests for better code coverage. 

## How are existing users impacted? What migration steps/scripts do we need?

No impact.

## Coverage:

```
➜ go test -coverprofile coverage.out             
➜ go tool cover -func coverage.out | grep tinkerbell.go 
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:29:	GetWorkflowContexts	0.0%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:49:	GetWorkflowContextList	91.7%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:72:	GetWorkflowActions	100.0%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:81:	ReportActionStatus	86.5%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:138:	UpdateWorkflowData	100.0%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:155:	GetWorkflowData		85.7%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:168:	GetWorkflowMetadata	100.0%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:177:	GetWorkflowDataVersion	100.0%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:185:	getWorkflowsForWorker	100.0%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:196:	getWorkflowActions	100.0%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:206:	isApplicableToSend	87.5%
github.com/tinkerbell/tink/grpc-server/tinkerbell.go:233:	isLastAction		100.0%
```

