### PR TITLE
Fixed log levels in worker code

### DIFF
--- a/cmd/tink-worker/action.go
+++ b/cmd/tink-worker/action.go
@@ -295,11 +295,11 @@ func initializeDockerClient() (*client.Client, error) {
 			logger.SetLevel(logrus.TraceLevel)
 		default:
 			logger.SetLevel(logrus.InfoLevel)
-			logger.Errorln("Invalid value for WORKER_LOG_LEVEL", level, " .Setting it to default(Info)")
+			logger.Warningln("Invalid value for WORKER_LOG_LEVEL", level, " .Setting it to default(Info)")
 		}
 	} else {
 		logger.SetLevel(logrus.InfoLevel)
-		logger.Errorln("Variable WORKER_LOG_LEVEL is not set. Default is Info")
+		logger.Warningln("Variable WORKER_LOG_LEVEL is not set. Default is Info")
 	}
 	logger.SetFormatter(&logrus.JSONFormatter{})
 	return c, nil


### PR DESCRIPTION
## Description

Changed log level from error to warning in worker code.

## Why is this needed


## How Has This Been Tested?
This has been tested with the workflow.


## How are existing users impacted? What migration steps/scripts do we need?

No impact on existing user and no migration script needed.
