### PR TITLE
Fix for Terraform provisioning #103

### DIFF
--- a/deploy/terraform/install_package.sh
+++ b/deploy/terraform/install_package.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+YUM="yum"
+APT="apt"
+PIP3="pip3"
+YUM_CONFIG_MGR="yum-config-manager"
+WHICH_YUM=$(command -v $YUM)
+WHICH_APT=$(command -v $APT)
+YUM_INSTALL="$YUM install"
+APT_INSTALL="$APT install"
+PIP3_INSTALL="$PIP3 install"
+declare -a YUM_LIST=("https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm"
+	"docker-ce"
+	"docker-ce-cli"
+	"epel-release"
+	"python3")
+declare -a APT_LIST=("docker"
+	"docker-compose")
+
+add_yum_repo() (
+	$YUM_CONFIG_MGR --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+)
+
+update_yum() (
+	$YUM_INSTALL -y yum-utils
+	add_yum_repo
+)
+
+update_apt() (
+	$APT update
+	DEBIAN_FRONTEND=noninteractive $APT --yes --force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+)
+
+restart_docker_service() (
+	service docker restart
+)
+
+install_yum_packages() (
+	$YUM_INSTALL "${YUM_LIST[@]}" -y
+)
+
+install_pip3_packages() (
+	$PIP3_INSTALL docker-compose
+)
+
+install_apt_packages() (
+	$APT_INSTALL "${APT_LIST[@]}" -y
+)
+
+main() (
+	if [[ -n $WHICH_YUM ]]; then
+		update_yum
+		install_yum_packages
+		install_pip3_packages
+		restart_docker_service
+	elif [[ -n $WHICH_APT ]]; then
+		update_apt
+		install_apt_packages
+		restart_docker_service
+	else
+		echo "Unknown platform. Error while installing the required packages"
+		exit 1
+	fi
+)
+
+main

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -20,6 +20,9 @@ resource "packet_device" "tink-provisioner" {
   billing_cycle    = "hourly"
   project_id       = var.project_id
   network_type     = "hybrid"
+  user_data        = "${file("install_package.sh")}"
+}
+
 }
 
 # Create a device and add it to tf_project_1


### PR DESCRIPTION
## Description

PR enables the terraform setup creation and installation of dependent packages like `docker` and `docker-compose`. 
This script is written in such a way where it can be extended to add the other dependent packages.  

## Why is this needed

https://github.com/tinkerbell/tinkerbell.org/issues/103

Fixes: #

- [x] Added a script to install dependent packages. 
 
## How Has This Been Tested?

Testing has been completed by creating tink-provisioner using terraform for OS `centos_8` and `ubuntu_18_04`. Below are the test results. 

- [x] Ubunut result
```
root@tink-provisioner-cb:~# lsb_release -a 
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.5 LTS
Release:	18.04
Codename:	bionic
root@tink-provisioner-cb:~# docker --version 
Docker version 19.03.6, build 369ce74a3c
root@tink-provisioner-cb:~# docker-compose --version 
docker-compose version 1.17.1, build unknown
```

- [x] Centos result 
```
[root@tink-provisioner-cb ~]# lsb_release -a 
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	CentOS
Description:	CentOS Linux release 8.1.1911 (Core) 
Release:	8.1.1911
Codename:	Core
[root@tink-provisioner-cb ~]# docker --version 
Docker version 19.03.12, build 48a66213fe
[root@tink-provisioner-cb ~]# docker-compose --version 
docker-compose version 1.26.2, build unknown
```

## Documentation required

- Status of execution of the script can be checked from location `/var/log/cloud-init-output.log` 



