### PR TITLE
Add codecov as part of ci checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,10 @@ jobs:
       uses: golangci/golangci-lint-action@v1
       with:
         version: v1.30
-    - name: go vet
-      run: go test ./...
+    - name: go test
+      run: go test -coverprofile=coverage.txt ./...
+    - name: upload codecov
+      run: bash <(curl -s https://codecov.io/bash)
     - name: Build binaries
       run: make
     - name: Upload tink-server binary

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Tinkerbell
 
 [![Build Status](https://cloud.drone.io/api/badges/tinkerbell/tink/status.svg)](https://cloud.drone.io/tinkerbell/tink)
+[![codecov](https://codecov.io/gh/tinkerbell/tink/branch/master/graph/badge.svg)](https://codecov.io/gh/tinkerbell/tink)
 
 It is comprised of following five major components:
 


### PR DESCRIPTION
Osie uses codecov already, this PR extends its use with the tink
repository.

Right now there is not support for PR comments or things like that. It
just updates codecov