### PR TITLE
Increase go test timeout for vagrant tests

### DIFF
--- a/.github/workflows/vagrant-packet.yaml
+++ b/.github/workflows/vagrant-packet.yaml
@@ -14,4 +14,4 @@ jobs:
     - name: Vagrant Test
       run: |
         export VAGRANT_DEFAULT_PROVIDER="virtualbox"
-        go test -v ./test/_vagrant
+        go test --timeout 1h -v ./test/_vagrant

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d // indirect
 	golang.org/x/text v0.3.2 // indirect


### PR DESCRIPTION
Right now there is only one test that runs as part of the vagrant
test suite the default go test timeout (10s) is enough.

It won't stay for long.
