### PR TITLE
Fixed log message format 

### DIFF
--- a/grpc-server/tinkerbell.go
+++ b/grpc-server/tinkerbell.go
@@ -2,6 +2,7 @@ package grpcserver
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/tinkerbell/tink/db"
@@ -90,7 +91,7 @@ func (s *server) ReportActionStatus(context context.Context, req *pb.WorkflowAct
 		return nil, status.Errorf(codes.InvalidArgument, errInvalidActionName)
 	}
 
-	logger.Info(msgReceivedStatus, req.GetActionStatus())
+	logger.Info(fmt.Sprintf(msgReceivedStatus, req.GetActionStatus()))
 
 	wfContext, err := s.db.GetWorkflowContexts(context, wfID)
 	if err != nil {
@@ -130,7 +131,7 @@ func (s *server) ReportActionStatus(context context.Context, req *pb.WorkflowAct
 	if err != nil {
 		return &pb.Empty{}, status.Error(codes.Aborted, err.Error())
 	}
-	logger.Info(msgCurrentWfContext, wfContext)
+	logger.Info(fmt.Sprintf(msgCurrentWfContext, wfContext))
 	return &pb.Empty{}, nil
 }
 
@@ -218,12 +219,12 @@ func isApplicableToSend(context context.Context, wfContext *pb.WorkflowContext, 
 		}
 		if wfContext.GetCurrentActionIndex() == 0 {
 			if actions.ActionList[wfContext.GetCurrentActionIndex()+1].GetWorkerId() == workerID {
-				logger.Info(msgSendWfContext, wfContext.GetWorkflowId())
+				logger.Info(fmt.Sprintf(msgSendWfContext, wfContext.GetWorkflowId()))
 				return true
 			}
 		}
 	} else if actions.ActionList[wfContext.GetCurrentActionIndex()].GetWorkerId() == workerID {
-		logger.Info(msgSendWfContext, wfContext.GetWorkflowId())
+		logger.Info(fmt.Sprintf(msgSendWfContext, wfContext.GetWorkflowId()))
 		return true
 
 	}

--- a/grpc-server/tinkerbell.go
+++ b/grpc-server/tinkerbell.go
@@ -3,6 +3,7 @@ package grpcserver
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/tinkerbell/tink/db"
@@ -22,7 +23,7 @@ const (
 	errInvalidActionReported = "reported action name does not match the current action details"
 
 	msgReceivedStatus   = "received action status: %s"
-	msgCurrentWfContext = "current workflow context: %s"
+	msgCurrentWfContext = "current workflow context"
 	msgSendWfContext    = "send workflow context: %s"
 )
 
@@ -91,7 +92,8 @@ func (s *server) ReportActionStatus(context context.Context, req *pb.WorkflowAct
 		return nil, status.Errorf(codes.InvalidArgument, errInvalidActionName)
 	}
 
-	logger.Info(fmt.Sprintf(msgReceivedStatus, req.GetActionStatus()))
+	l := logger.With("actionName", req.GetActionName(), "workflowID", req.GetWorkflowId())
+	l.Info(fmt.Sprintf(msgReceivedStatus, req.GetActionStatus()))
 
 	wfContext, err := s.db.GetWorkflowContexts(context, wfID)
 	if err != nil {
@@ -131,7 +133,17 @@ func (s *server) ReportActionStatus(context context.Context, req *pb.WorkflowAct
 	if err != nil {
 		return &pb.Empty{}, status.Error(codes.Aborted, err.Error())
 	}
-	logger.Info(fmt.Sprintf(msgCurrentWfContext, wfContext))
+
+	l = logger.With(
+		"workflowID", wfContext.GetWorkflowId(),
+		"currentWorker", wfContext.GetCurrentWorker(),
+		"currentTask", wfContext.GetCurrentTask(),
+		"currentAction", wfContext.GetCurrentAction(),
+		"currentActionIndex", strconv.FormatInt(wfContext.GetCurrentActionIndex(), 10),
+		"currentActionState", wfContext.GetCurrentActionState(),
+		"totalNumberOfActions", wfContext.GetTotalNumberOfActions(),
+	)
+	l.Info(msgCurrentWfContext)
 	return &pb.Empty{}, nil
 }
 


### PR DESCRIPTION
## Why is this needed

Fixes: #259 


## How Has This Been Tested?
Tested by executing a workflow on Vagrant setup. 

## Logs
```
tink-server_1  | {"level":"info","ts":1597993697.729267,"caller":"tink-server/main.go:30","msg":"starting version c94241f","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993697.7294364,"caller":"metrics/metrics.go:58","msg":"initializing label values","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993697.7324421,"caller":"grpc-server/grpc_server.go:77","msg":"serving grpc","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993697.7331507,"caller":"http-server/http_server.go:90","msg":"serving http","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993707.0710828,"caller":"grpc-server/workflow.go:153","msg":"listworkflows","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993714.4313056,"caller":"grpc-server/workflow.go:119","msg":"deleteworkflow","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993714.4314113,"caller":"grpc-server/workflow.go:137","msg":"deleting a workflow","service":"github.com/tinkerbell/tink","workflowID":"668efc38-5072-40ed-b575-98cc4f8dc8e7"}
tink-server_1  | {"level":"info","ts":1597993714.4338477,"caller":"grpc-server/workflow.go:147","msg":"done deleting a workflow","service":"github.com/tinkerbell/tink","workflowID":"668efc38-5072-40ed-b575-98cc4f8dc8e7"}
tink-server_1  | {"level":"info","ts":1597993718.7341084,"caller":"grpc-server/workflow.go:29","msg":"createworkflow","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993718.7341583,"caller":"grpc-server/workflow.go:59","msg":"creating a new workflow","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993718.7396371,"caller":"grpc-server/workflow.go:71","msg":"done creating a new workflow","service":"github.com/tinkerbell/tink","workflowID":"9abf6d93-e117-4ca0-be11-1bb6f31cb371"}
tink-server_1  | {"level":"info","ts":1597993833.5934675,"caller":"grpc-server/tinkerbell.go:239","msg":"send workflow context: 9abf6d93-e117-4ca0-be11-1bb6f31cb371","service":"github.com/tinkerbell/tink"}
tink-server_1  | {"level":"info","ts":1597993833.5954807,"caller":"grpc-server/tinkerbell.go:96","msg":"received action status: ACTION_IN_PROGRESS","service":"github.com/tinkerbell/tink","actionName":"hello_world","workflowID":"9abf6d93-e117-4ca0-be11-1bb6f31cb371"}
tink-server_1  | {"level":"info","ts":1597993833.5994563,"caller":"grpc-server/tinkerbell.go:146","msg":"current workflow context","service":"github.com/tinkerbell/tink","workflowID":"9abf6d93-e117-4ca0-be11-1bb6f31cb371","currentWorker":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","currentTask":"hello world","currentAction":"hello_world","currentActionIndex":"0","currentActionState":"ACTION_IN_PROGRESS","totalNumberOfActions":1}
tink-server_1  | {"level":"info","ts":1597993833.9179895,"caller":"grpc-server/tinkerbell.go:96","msg":"received action status: ACTION_SUCCESS","service":"github.com/tinkerbell/tink","actionName":"hello_world","workflowID":"9abf6d93-e117-4ca0-be11-1bb6f31cb371"}
tink-server_1  | {"level":"info","ts":1597993833.9213414,"caller":"grpc-server/tinkerbell.go:146","msg":"current workflow context","service":"github.com/tinkerbell/tink","workflowID":"9abf6d93-e117-4ca0-be11-1bb6f31cb371","currentWorker":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","currentTask":"hello world","currentAction":"hello_world","currentActionIndex":"0","currentActionState":"ACTION_SUCCESS","totalNumberOfActions":1}
```