### PR TITLE
bump timeout from 5min to 10min

### DIFF
--- a/test/_vagrant/vagrant_test.go
+++ b/test/_vagrant/vagrant_test.go
@@ -126,9 +126,9 @@ func TestVagrantSetupGuide(t *testing.T) {
 				return
 			}
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
-	t.Fatal("Workflow never got to a complite state or it didn't make it on time (5m)")
+	t.Fatal("Workflow never got to a complite state or it didn't make it on time (10m)")
 }
 
 func createWorkflow(ctx context.Context, templateID string) (string, error) {


### PR DESCRIPTION
There is a timeout for the Vagrant Setup guide test at 5minutes. If the
expected set of statuses does not show up in 5 minutes the tests gets
marked as failed.

It works locally but in CI it fails, so this is an attempt to see if it
is only a resource issue