### PR TITLE
Removed GlobalTimeout from the template definition

### DIFF
--- a/cmd/tink-cli/sample.tmpl
+++ b/cmd/tink-cli/sample.tmpl
@@ -1,6 +1,5 @@
 version: '0.1'
 name: packet_osie_provision
-global_timeout: 600
 tasks:
 - name: "OS Installation"
   worker: "{{.device_1}}"

--- a/pkg/template_validator_test.go
+++ b/pkg/template_validator_test.go
@@ -9,7 +9,6 @@ import (
 const (
 	validTemplate = `version: "0.1"
 name: hello_world_workflow
-global_timeout: 600
 tasks:
   - name: "hello world"
     worker: "{{.device_1}}"
@@ -20,7 +19,6 @@ tasks:
 
 	invalidTemplate = `version: "0.1"
 name: hello_world_workflow
-global_timeout: 600
 tasks:
   - name: "hello world"
     worker: "{{.device_1}}"
@@ -145,7 +143,6 @@ func withDuplicateActionName() workflowModifier {
 func workflow(m ...workflowModifier) *Workflow {
 	wf := &Workflow{
 		ID:            "ce2e62ed-826f-4485-a39f-a82bb74338e2",
-		GlobalTimeout: 900,
 		Name:          "ubuntu-provisioning",
 		Tasks: []Task{
 			{

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -5,7 +5,6 @@ type Workflow struct {
 	Version       string `yaml:"version"`
 	Name          string `yaml:"name"`
 	ID            string `yaml:"id"`
-	GlobalTimeout int    `yaml:"global_timeout"`
 	Tasks         []Task `yaml:"tasks"`
 }
 

--- a/test/_vagrant/vagrant_test.go
+++ b/test/_vagrant/vagrant_test.go
@@ -147,7 +147,6 @@ func registerTemplate(ctx context.Context) (string, error) {
 		Name: "hello-world",
 		Data: `version: "0.1"
 name: hello_world_workflow
-global_timeout: 600
 tasks:
   - name: "hello world"
     worker: "{{.device_1}}"

--- a/test/data/template/sample_1
+++ b/test/data/template/sample_1
@@ -1,6 +1,5 @@
 version: '0.1'
 name: packet_osie_provision
-global_timeout: 600
 tasks:
 - name: "run_one_worker"
   worker: "{{.device_1}}"

--- a/test/data/template/sample_2
+++ b/test/data/template/sample_2
@@ -1,6 +1,5 @@
 version: '0.1'
 name: packet_osie_provision
-global_timeout: 600
 tasks:
 - name: "timeout-task"
   worker: "{{.device_1}}"

--- a/test/data/template/sample_3
+++ b/test/data/template/sample_3
@@ -1,6 +1,5 @@
 version: '0.1'
 name: packet_osie_provision
-global_timeout: 600
 tasks:
 - name: "run-first-worker"
   worker: "{{.device_1}}"


### PR DESCRIPTION
Signed-off-by: parauliya <aman@infracloud.io>

## Description

This PR will remove the global_timeout field from template which was unused.

## Why is this needed

Fixes: #198 

## How Has This Been Tested?
I ran an e2e test using vagrant before raising this PR.

## How are existing users impacted? What migration steps/scripts do we need?
Now the existing user need not to have` global_timeout` field in the template.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
