### PR TITLE
Fixed the duplicate name issue while creating a template

### DIFF
--- a/db/mock/template.go
+++ b/db/mock/template.go
@@ -2,13 +2,36 @@ package mock
 
 import (
 	"context"
+	"errors"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	uuid "github.com/satori/go.uuid"
 )
 
+type template struct {
+	id   uuid.UUID
+	data string
+}
+
+var templateDB = map[string]interface{}{}
+
 // CreateTemplate creates a new workflow template
 func (d DB) CreateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error {
+	if len(templateDB) > 0 {
+		if _, ok := templateDB[name]; ok {
+			return errors.New("Template name already exist in the database")
+		}
+		templateDB[name] = template{
+			id:   id,
+			data: data,
+		}
+
+	} else {
+		templateDB[name] = template{
+			id:   id,
+			data: data,
+		}
+	}
 	return nil
 }
 
@@ -19,6 +42,12 @@ func (d DB) GetTemplate(ctx context.Context, id string) (string, string, error) 
 
 // DeleteTemplate deletes a workflow template
 func (d DB) DeleteTemplate(ctx context.Context, name string) error {
+	if len(templateDB) > 0 {
+		if _, ok := templateDB[name]; !ok {
+			return errors.New("Template name does not exist")
+		}
+		delete(templateDB, name)
+	}
 	return nil
 }
 
@@ -30,4 +59,11 @@ func (d DB) ListTemplates(fn func(id, n string, in, del *timestamp.Timestamp) er
 // UpdateTemplate update a given template
 func (d DB) UpdateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error {
 	return nil
+}
+
+// ClearTemplateDB clear all the templates
+func (d DB) ClearTemplateDB() {
+	for name := range templateDB {
+		delete(templateDB, name)
+	}
 }

--- a/deploy/db/tinkerbell-init.sql
+++ b/deploy/db/tinkerbell-init.sql
@@ -13,7 +13,7 @@ CREATE INDEX IF NOT EXISTS idxgin_type ON hardware USING GIN (data JSONB_PATH_OP
 
 CREATE TABLE IF NOT EXISTS template (
         id UUID UNIQUE NOT NULL
-        , name VARCHAR(200) NOT NULL
+        , name VARCHAR(200) UNIQUE NOT NULL
         , created_at TIMESTAMPTZ
         , updated_at TIMESTAMPTZ
         , deleted_at TIMESTAMPTZ

--- a/grpc-server/template.go
+++ b/grpc-server/template.go
@@ -31,7 +31,6 @@ func (s *server) CreateTemplate(ctx context.Context, in *template.WorkflowTempla
 
 	logger.Info(msg)
 	err := fn()
-	logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
 		l := logger
@@ -41,6 +40,7 @@ func (s *server) CreateTemplate(ctx context.Context, in *template.WorkflowTempla
 		l.Error(err)
 		return &template.CreateResponse{}, err
 	}
+	logger.Info("done " + msg)
 	return &template.CreateResponse{Id: id.String()}, err
 }
 

--- a/grpc-server/template_test.go
+++ b/grpc-server/template_test.go
@@ -1,0 +1,75 @@
+package grpcserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tinkerbell/tink/db/mock"
+	pb "github.com/tinkerbell/tink/protos/template"
+)
+
+const (
+	template1 = `version: "0.1"
+name: hello_world_workflow
+global_timeout: 600
+tasks:
+  - name: "hello world"
+    worker: "{{.device_1}}"
+    actions:
+    - name: "hello_world"
+      image: hello-world
+      timeout: 60`
+
+	template2 = `version: "0.1"
+name: hello_world_workflow
+global_timeout: 600
+tasks:
+  - name: "hello world again"
+    worker: "{{.device_1}}"
+    actions:
+  	- name: "hello_world_again"
+      image: hello-world
+      timeout: 60`
+)
+
+func TestDuplicateTemplateName(t *testing.T) {
+	type (
+		args struct {
+			db   mock.DB
+			name string
+		}
+		want struct {
+			expectedError bool
+		}
+	)
+	testCases := map[string]struct {
+		args args
+		want want
+	}{
+		"test_1": {
+			args: args{
+				db:   mock.DB{},
+				name: "template_1",
+			},
+			want: want{
+				expectedError: true,
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			s := testServer(tc.args.db)
+			res, err := s.CreateTemplate(context.TODO(), &pb.WorkflowTemplate{Name: tc.args.name, Data: template1})
+			assert.Nil(t, err)
+			assert.NotNil(t, res)
+			if err == nil {
+				_, err = s.CreateTemplate(context.TODO(), &pb.WorkflowTemplate{Name: tc.args.name, Data: template2})
+			}
+			if err != nil {
+				assert.Error(t, err)
+				assert.True(t, tc.want.expectedError)
+			}
+		})
+	}
+}

--- a/grpc-server/tinkerbell_test.go
+++ b/grpc-server/tinkerbell_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tinkerbell/tink/db"
 	"github.com/tinkerbell/tink/db/mock"
+	"github.com/tinkerbell/tink/metrics"
 	pb "github.com/tinkerbell/tink/protos/workflow"
 )
 
@@ -39,7 +40,7 @@ func TestMain(m *testing.M) {
 
 	l, _, _ := log.Init("github.com/tinkerbell/tink")
 	logger = l.Package("grpcserver")
-
+	metrics.SetupMetrics("onprem", logger)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Name of the template which is used to provide with -n flag while creating a template should be unique.
But there was an issue because of which it was accepting duplicate name as well.
This PR fixed the above issue.

Signed-off-by: parauliya <aman@infracloud.io>

## Description

Name of the template which is used to provide with -n flag while creating a template should be unique.
But there was an issue because of which it was accepting duplicate name as well.
This PR fixed the above issue.

## Why is this needed
Same as Description.

## How Has This Been Tested?
I tried to create multiple template with same name but now they are not being created because of the same name.

## How are existing users impacted? What migration steps/scripts do we need?
User need to provide the unique name for each template it is creating in the database.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
