### PR TITLE
Switching from logrus to packethost/pkg/log in worker

### DIFF
--- a/cmd/tink-server/main.go
+++ b/cmd/tink-server/main.go
@@ -19,14 +19,13 @@ var (
 )
 
 func main() {
-	log, cleanup, err := log.Init("github.com/tinkerbell/tink")
+	log, err := log.Init("github.com/tinkerbell/tink")
 
 	if err != nil {
 		panic(err)
 	}
 	logger = log
-	defer cleanup()
-
+	defer logger.Close()
 	log.Info("starting version " + version)
 
 	ctx, closer := context.WithCancel(context.Background())

--- a/cmd/tink-worker/main.go
+++ b/cmd/tink-worker/main.go
@@ -34,7 +34,7 @@ var (
 )
 
 func main() {
-	log, cleanup, err := log.Init(serviceKey)
+	log, err := log.Init(serviceKey)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/tink-worker/main.go
+++ b/cmd/tink-worker/main.go
@@ -5,7 +5,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/packethost/pkg/log"
+	"github.com/pkg/errors"
 	"github.com/tinkerbell/tink/client"
 	pb "github.com/tinkerbell/tink/protos/workflow"
 	"google.golang.org/grpc"
@@ -14,36 +15,46 @@ import (
 const (
 	retryIntervalDefault = 3
 	retryCountDefault    = 3
+
+	serviceKey           = "github.com/tinkerbell/tink"
+	invalidRetryInterval = "invalid RETRY_INTERVAL, using default (seconds)"
+	invalidMaxRetry      = "invalid MAX_RETRY, using default"
+
+	errWorker = "worker finished with error"
 )
 
 var (
 	rClient       pb.WorkflowSvcClient
 	retryInterval time.Duration
 	retries       int
-)
+	logger        log.Logger
 
-var (
 	// version is set at build time
 	version = "devel"
-
-	logger = logrus.New()
 )
 
 func main() {
-	initializeLogger()
-	logger.Debug("Starting version " + version)
+	log, cleanup, err := log.Init(serviceKey)
+	if err != nil {
+		panic(err)
+	}
+	logger = log
+	defer logger.Close()
+	log.With("version", version).Info("starting")
 	setupRetry()
 	if setupErr := client.Setup(); setupErr != nil {
-		logger.Fatalln(setupErr)
+		log.Error(setupErr)
+		os.Exit(1)
 	}
 	conn, err := tryClientConnection()
 	if err != nil {
-		logger.Fatalln(err)
+		log.Error(err)
+		os.Exit(1)
 	}
 	rClient = pb.NewWorkflowSvcClient(conn)
 	err = processWorkflowActions(rClient)
 	if err != nil {
-		logger.Errorln("worker Finished with error", err)
+		log.Error(errors.Wrap(err, errWorker))
 	}
 }
 
@@ -53,8 +64,7 @@ func tryClientConnection() (*grpc.ClientConn, error) {
 		c, e := client.GetConnection()
 		if e != nil {
 			err = e
-			logger.Errorln(err)
-			logger.Errorf("retrying after %v seconds", retryInterval)
+			logger.With("error", err, "duration", retryInterval).Info("failed to connect, sleeping before retrying")
 			<-time.After(retryInterval * time.Second)
 			continue
 		}
@@ -66,12 +76,12 @@ func tryClientConnection() (*grpc.ClientConn, error) {
 func setupRetry() {
 	interval := os.Getenv("RETRY_INTERVAL")
 	if interval == "" {
-		logger.Infof("RETRY_INTERVAL not set. Using default, %d seconds\n", retryIntervalDefault)
+		logger.With("default", retryIntervalDefault).Info("RETRY_INTERVAL not set")
 		retryInterval = retryIntervalDefault
 	} else {
 		interval, err := time.ParseDuration(interval)
 		if err != nil {
-			logger.Warningf("Invalid RETRY_INTERVAL set. Using default, %d seconds.\n", retryIntervalDefault)
+			logger.With("default", retryIntervalDefault).Info(invalidRetryInterval)
 			retryInterval = retryIntervalDefault
 		} else {
 			retryInterval = interval
@@ -80,12 +90,12 @@ func setupRetry() {
 
 	maxRetry := os.Getenv("MAX_RETRY")
 	if maxRetry == "" {
-		logger.Infof("MAX_RETRY not set. Using default, %d retries.\n", retryCountDefault)
+		logger.With("default", retryCountDefault).Info("MAX_RETRY not set")
 		retries = retryCountDefault
 	} else {
 		max, err := strconv.Atoi(maxRetry)
 		if err != nil {
-			logger.Warningf("Invalid MAX_RETRY set. Using default, %d retries.\n", retryCountDefault)
+			logger.With("default", retryCountDefault).Info(invalidMaxRetry)
 			retries = retryCountDefault
 		} else {
 			retries = max

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,10 +5,6 @@ services:
     restart: unless-stopped
     environment:
       FACILITY: ${FACILITY:-onprem}
-      PACKET_ENV: ${PACKET_ENV:-testing}
-      PACKET_VERSION: ${PACKET_VERSION:-ignored}
-      ROLLBAR_TOKEN: ${ROLLBAR_TOKEN:-ignored}
-      ROLLBAR_DISABLE: ${ROLLBAR_DISABLE:-1}
       PGDATABASE: tinkerbell
       PGHOST: db
       PGPASSWORD: tinkerbell
@@ -97,10 +93,6 @@ services:
       API_AUTH_TOKEN: ${PACKET_API_AUTH_TOKEN:-ignored}
       API_CONSUMER_TOKEN: ${PACKET_CONSUMER_TOKEN:-ignored}
       FACILITY_CODE: ${FACILITY:-onprem}
-      PACKET_ENV: ${PACKET_ENV:-testing}
-      PACKET_VERSION: ${PACKET_VERSION:-ignored}
-      ROLLBAR_TOKEN: ${ROLLBAR_TOKEN:-ignored}
-      ROLLBAR_DISABLE: ${ROLLBAR_DISABLE:-1}
       MIRROR_HOST: ${TINKERBELL_NGINX_IP:-127.0.0.1}
       DNS_SERVERS: 8.8.8.8
       PUBLIC_IP: $TINKERBELL_HOST_IP
@@ -137,10 +129,6 @@ services:
     restart: unless-stopped
     network_mode: host
     environment:
-      ROLLBAR_TOKEN: ${ROLLBAR_TOKEN-ignored}
-      ROLLBAR_DISABLE: 1
-      PACKET_ENV: testing
-      PACKET_VERSION: ${PACKET_VERSION:-ignored}
       GRPC_PORT: 42115
       HEGEL_FACILITY: ${FACILITY:-onprem}
       HEGEL_USE_TLS: 0

--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -80,8 +80,6 @@ export TINKERBELL_REGISTRY_PASSWORD="$registry_password"
 
 # Legacy options, to be deleted:
 export FACILITY=onprem
-export ROLLBAR_TOKEN=ignored
-export ROLLBAR_DISABLE=1
 EOF
 )
 

--- a/go.mod
+++ b/go.mod
@@ -24,18 +24,16 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/packethost/pkg v0.0.0-20190410153520-e8e15f4ce770
+	github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
-	github.com/rollbar/rollbar-go v1.0.2 // indirect
-	github.com/sirupsen/logrus v1.4.1
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d // indirect
-	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
@@ -153,8 +155,8 @@ github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2i
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/packethost/pkg v0.0.0-20190410153520-e8e15f4ce770 h1:M/ErkHz96yXYNdcu0G7kX5Qa1HUliL5QczNdA9/0k40=
-github.com/packethost/pkg v0.0.0-20190410153520-e8e15f4ce770/go.mod h1:cbOkI4WbX7B68Nj552pbadMrjVy2oMIVazIEo7z+qWQ=
+github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550 h1:/ojL7LAVjyH1MY+db0+j6rcWU3UWWpzHksYFsHWs9vQ=
+github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550/go.mod h1:GSv7cTtIjns4yc0pyajaM1RE/KE4djJONoblFIRDrxA=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
@@ -196,6 +198,8 @@ github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
+github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
@@ -250,6 +254,7 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -264,8 +269,10 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qdNLDHHtQ4mlgQIZPPNA=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
@@ -289,6 +296,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/genproto v0.0.0-20190708153700-3bdd9d9f5532/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884 h1:fiNLklpBwWK1mth30Hlwk+fcdBmIALlgF5iy77O37Ig=
@@ -297,6 +305,7 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaR
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=

--- a/grpc-server/tinkerbell_test.go
+++ b/grpc-server/tinkerbell_test.go
@@ -34,11 +34,8 @@ func testServer(db db.Database) *server {
 }
 
 func TestMain(m *testing.M) {
-	os.Setenv("PACKET_ENV", "test")
-	os.Setenv("PACKET_VERSION", "ignored")
-	os.Setenv("ROLLBAR_TOKEN", "ignored")
 
-	l, _, _ := log.Init("github.com/tinkerbell/tink")
+	l, _ := log.Init("github.com/tinkerbell/tink")
 	logger = l.Package("grpcserver")
 	metrics.SetupMetrics("onprem", logger)
 	os.Exit(m.Run())

--- a/http-server/http_handlers_test.go
+++ b/http-server/http_handlers_test.go
@@ -53,12 +53,7 @@ func (s *server) Push(ctx context.Context, in *hardware.PushRequest) (*hardware.
 }
 
 func TestMain(m *testing.M) {
-	os.Setenv("PACKET_ENV", "test")
-	os.Setenv("PACKET_VERSION", "ignored")
-	os.Setenv("ROLLBAR_TOKEN", "ignored")
-
-	logger, _, _ = log.Init("github.com/tinkerbell/tink")
-
+	logger, _ = log.Init("github.com/tinkerbell/tink")
 	lis = bufconn.Listen(bufSize)
 	s := grpc.NewServer()
 	hardware.RegisterHardwareServiceServer(s, &server{})
@@ -67,7 +62,6 @@ func TestMain(m *testing.M) {
 			logger.Info("Server exited with error: %v", err)
 		}
 	}()
-
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## Description

Replacing `logrus` with `packethost/pkg/log`.

Depends on:
- [Boots PR #77](https://github.com/tinkerbell/boots/pull/77)
- [Hegel PR #33](https://github.com/tinkerbell/hegel/pull/33)

## Why is this needed

The PR aims to keep the logging package consistent across the Tink repository. 

## How Has This Been Tested?

Tested the changes by executing an end-to-end workflow. 

## Worker Logs
```
{"log":"{\"level\":\"info\",\"ts\":1598612543.5217416,\"caller\":\"tink-worker/main.go:48\",\"msg\":\"starting version: 6960d5f\",\"service\":\"github.com/tinkerbell/tink\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.526199655Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.5223653,\"caller\":\"tink-worker/main.go:85\",\"msg\":\"RETRY_INTERVAL not set, using default 3 seconds\",\"service\":\"github.com/tinkerbell/tink\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.526229686Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.5223973,\"caller\":\"tink-worker/main.go:99\",\"msg\":\"MAX_RETRY not set, using default 3 retries\",\"service\":\"github.com/tinkerbell/tink\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.526236012Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.5452757,\"caller\":\"tink-worker/worker.go:142\",\"msg\":\"starting with action\",\"service\":\"github.com/tinkerbell/tink\",\"workerId\":\"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94\",\"workflowId\":\"b3a88595-5bfd-40ed-bd32-766adeab4fa2\",\"actionName\":\"hello_world\",\"taskName\":\"hello world\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.545666793Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.5510116,\"caller\":\"tink-worker/worker.go:166\",\"msg\":\"sent action status\",\"service\":\"github.com/tinkerbell/tink\",\"workerId\":\"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94\",\"workflowId\":\"b3a88595-5bfd-40ed-bd32-766adeab4fa2\",\"actionName\":\"hello_world\",\"taskName\":\"hello world\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.551388082Z"}
{"log":"{\"status\":\"Pulling from hello-world\",\"id\":\"latest\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.644575307Z"}
{"log":"{\"status\":\"Pulling fs layer\",\"progressDetail\":{},\"id\":\"0e03bdcc26d7\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.644659223Z"}
{"log":"{\"status\":\"Downloading\",\"progressDetail\":{\"current\":730,\"total\":2529},\"progress\":\"[==============\\u003e                                    ]     730B/2.529kB\",\"id\":\"0e03bdcc26d7\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.66942451Z"}
{"log":"{\"status\":\"Downloading\",\"progressDetail\":{\"current\":2529,\"total\":2529},\"progress\":\"[==================================================\\u003e]  2.529kB/2.529kB\",\"id\":\"0e03bdcc26d7\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.669436361Z"}
{"log":"{\"status\":\"Verifying Checksum\",\"progressDetail\":{},\"id\":\"0e03bdcc26d7\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.669439988Z"}
{"log":"{\"status\":\"Download complete\",\"progressDetail\":{},\"id\":\"0e03bdcc26d7\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.66944226Z"}
{"log":"{\"status\":\"Extracting\",\"progressDetail\":{\"current\":2529,\"total\":2529},\"progress\":\"[==================================================\\u003e]  2.529kB/2.529kB\",\"id\":\"0e03bdcc26d7\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.66944429Z"}
{"log":"{\"status\":\"Extracting\",\"progressDetail\":{\"current\":2529,\"total\":2529},\"progress\":\"[==================================================\\u003e]  2.529kB/2.529kB\",\"id\":\"0e03bdcc26d7\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.66944685Z"}
{"log":"{\"status\":\"Pull complete\",\"progressDetail\":{},\"id\":\"0e03bdcc26d7\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.731208642Z"}
{"log":"{\"status\":\"Digest: sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.731223756Z"}
{"log":"{\"status\":\"Status: Downloaded newer image for 192.168.1.1/hello-world:latest\"}\r\r\n","stream":"stdout","time":"2020-08-28T11:02:23.731226604Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.6948822,\"caller\":\"tink-worker/action.go:203\",\"msg\":\"starting container with cmd: []\",\"service\":\"github.com/tinkerbell/tink\",\"workflowId\":\"b3a88595-5bfd-40ed-bd32-766adeab4fa2\",\"workerId\":\"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94\",\"actionName\":\"hello_world\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.731228638Z"}
{"log":"\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864270483Z"}
{"log":"Hello from Docker!\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864278931Z"}
{"log":"This message shows that your installation appears to be working correctly.\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864281213Z"}
{"log":"\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864283136Z"}
{"log":"To generate this message, Docker took the following steps:\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864284705Z"}
{"log":" 1. The Docker client contacted the Docker daemon.\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864286483Z"}
{"log":" 2. The Docker daemon pulled the \"hello-world\" image from the Docker Hub.\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864288907Z"}
{"log":"    (amd64)\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864290903Z"}
{"log":" 3. The Docker daemon created a new container from that image which runs the\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864292477Z"}
{"log":"    executable that produces the output you are currently reading.\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864294192Z"}
{"log":" 4. The Docker daemon streamed that output to the Docker client, which sent it\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864295866Z"}
{"log":"    to your terminal.\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864297598Z"}
{"log":"\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864299188Z"}
{"log":"To try something more ambitious, you can run an Ubuntu container with:\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864300687Z"}
{"log":" $ docker run -it ubuntu bash\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864302378Z"}
{"log":"\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864303968Z"}
{"log":"Share images, automate workflows, and more with a free Docker ID:\r\n","stream":"stdout","time":"2020-08-28T11:02:23.86430546Z"}
{"log":" https://hub.docker.com/\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864307212Z"}
{"log":"\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864308793Z"}
{"log":"For more examples and ideas, visit:\r\n","stream":"stdout","time":"2020-08-28T11:02:23.86431029Z"}
{"log":" https://docs.docker.com/get-started/\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864311973Z"}
{"log":"\r\n","stream":"stdout","time":"2020-08-28T11:02:23.864313659Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.9096792,\"caller\":\"tink-worker/action.go:266\",\"msg\":\"starting to remove container: eff322d7a5a7bada3d179be6ec927ac2fcac8873c677d2d91d79cfe3fee359f2\",\"service\":\"github.com/tinkerbell/tink\",\"workflowId\":\"b3a88595-5bfd-40ed-bd32-766adeab4fa2\",\"workerId\":\"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94\",\"actionName\":\"hello_world\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.911821295Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.9113615,\"caller\":\"tink-worker/action.go:86\",\"msg\":\"container removed with status: ACTION_SUCCESS\",\"service\":\"github.com/tinkerbell/tink\",\"workflowId\":\"b3a88595-5bfd-40ed-bd32-766adeab4fa2\",\"workerId\":\"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94\",\"actionName\":\"hello_world\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.911833548Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.9113853,\"caller\":\"tink-worker/action.go:133\",\"msg\":\"action container exit status code: ACTION_SUCCESS\",\"service\":\"github.com/tinkerbell/tink\",\"workflowId\":\"b3a88595-5bfd-40ed-bd32-766adeab4fa2\",\"workerId\":\"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94\",\"actionName\":\"hello_world\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.91183715Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.9146202,\"caller\":\"tink-worker/worker.go:211\",\"msg\":\"sent action status\",\"service\":\"github.com/tinkerbell/tink\",\"workerId\":\"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94\",\"workflowId\":\"b3a88595-5bfd-40ed-bd32-766adeab4fa2\",\"actionName\":\"hello_world\",\"taskName\":\"hello world\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.915028437Z"}
{"log":"{\"level\":\"info\",\"ts\":1598612543.916867,\"caller\":\"tink-worker/worker.go:217\",\"msg\":\"reached to end of workflow\",\"service\":\"github.com/tinkerbell/tink\",\"workerId\":\"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94\",\"workflowId\":\"b3a88595-5bfd-40ed-bd32-766adeab4fa2\"}\r\n","stream":"stdout","time":"2020-08-28T11:02:23.917199393Z"}
```