### PR TITLE
Added the validation of template while creating it

### DIFF
--- a/db/mock/mock.go
+++ b/db/mock/mock.go
@@ -22,7 +22,7 @@ type DB struct {
 	GetWorkflowActionsFunc           func(ctx context.Context, wfID string) (*pb.WorkflowActionList, error)
 	UpdateWorkflowStateFunc          func(ctx context.Context, wfContext *pb.WorkflowContext) error
 	InsertIntoWorkflowEventTableFunc func(ctx context.Context, wfEvent *pb.WorkflowActionStatus, time time.Time) error
-
 	// template
+	TemplateDB      map[string]interface{}
 	GetTemplateFunc func(ctx context.Context, id string) (string, string, error)
 }

--- a/db/mock/template.go
+++ b/db/mock/template.go
@@ -8,30 +8,26 @@ import (
 	"github.com/google/uuid"
 )
 
-type template struct {
-	id   uuid.UUID
-	data string
+type Template struct {
+	ID   uuid.UUID
+	Data string
 }
-
-var templateDB = map[string]interface{}{}
 
 // CreateTemplate creates a new workflow template
 func (d DB) CreateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error {
-	if len(templateDB) > 0 {
-		if _, ok := templateDB[name]; ok {
-			return errors.New("Template name already exist in the database")
-		}
-		templateDB[name] = template{
-			id:   id,
-			data: data,
-		}
-
-	} else {
-		templateDB[name] = template{
-			id:   id,
-			data: data,
-		}
+	if d.TemplateDB == nil {
+		d.TemplateDB = make(map[string]interface{})
 	}
+
+	if _, ok := d.TemplateDB[name]; ok {
+		return errors.New("Template name already exist in the database")
+	}
+
+	d.TemplateDB[name] = Template{
+		ID:   id,
+		Data: data,
+	}
+
 	return nil
 }
 
@@ -42,12 +38,10 @@ func (d DB) GetTemplate(ctx context.Context, id string) (string, string, error) 
 
 // DeleteTemplate deletes a workflow template
 func (d DB) DeleteTemplate(ctx context.Context, name string) error {
-	if len(templateDB) > 0 {
-		if _, ok := templateDB[name]; !ok {
-			return errors.New("Template name does not exist")
-		}
-		delete(templateDB, name)
+	if d.TemplateDB != nil {
+		delete(d.TemplateDB, name)
 	}
+
 	return nil
 }
 
@@ -63,7 +57,5 @@ func (d DB) UpdateTemplate(ctx context.Context, name string, data string, id uui
 
 // ClearTemplateDB clear all the templates
 func (d DB) ClearTemplateDB() {
-	for name := range templateDB {
-		delete(templateDB, name)
-	}
+	d.TemplateDB = make(map[string]interface{})
 }

--- a/db/template.go
+++ b/db/template.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/tinkerbell/tink/pkg"
 )
 
 // CreateTemplate creates a new workflow template
@@ -16,6 +17,15 @@ func (d TinkDB) CreateTemplate(ctx context.Context, name string, data string, id
 	tx, err := d.instance.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return errors.Wrap(err, "BEGIN transaction")
+	}
+
+	wf, err := pkg.ParseYAML([]byte(data))
+	if err != nil {
+		return err
+	}
+	err = pkg.ValidateTemplate(wf)
+	if err != nil {
+		return err
 	}
 
 	_, err = tx.Exec(`

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
+	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect

--- a/pkg/template_validator_test.go
+++ b/pkg/template_validator_test.go
@@ -98,6 +98,11 @@ func TestValidateTemplate(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			name:          "long action name",
+			wf:            workflow(withLongActionName()),
+			expectedError: true,
+		},
+		{
 			name: "valid task name",
 			wf:   workflow(),
 		},
@@ -119,6 +124,12 @@ type workflowModifier func(*Workflow)
 func withLongTaskName() workflowModifier {
 	return func(wf *Workflow) {
 		wf.Tasks[0].Name = "this task has a very long name to test whether we recevice an error or not if a task has very long name, one that would probably go beyond the limit of not having a task name with more than two hundred characters"
+	}
+}
+
+func withLongActionName() workflowModifier {
+	return func(wf *Workflow) {
+		wf.Tasks[0].Actions[0].Name = "this action has a very long name to test whether we recevice an error or not if an action has very long name, one that would probably go beyond the limit of not having an action name with more than two hundred characters"
 	}
 }
 


### PR DESCRIPTION
## Description

This PR will validate a template. If `timeout` field for an action is not provided or provided with 0 value, then that will be considered as infinite timeout for that particular action.

## Why is this needed
This fix is required so that Provisioner should only depends on global timeout.

## How Has This Been Tested?
Added UT for the `CreateTemplate` API.
Also tested through e2e test to ensure that any existing feature doesn't break.

## How are existing users impacted? What migration steps/scripts do we need?
No Impact on existig user

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
