### PR TITLE
Simple refactors

### DIFF
--- a/grpc-server/hardware.go
+++ b/grpc-server/hardware.go
@@ -45,14 +45,13 @@ func (s *server) Push(ctx context.Context, in *hardware.PushRequest) (*hardware.
 	}
 
 	var fn func() error
-	msg := ""
+	const msg = "inserting into DB"
 	data, err := json.Marshal(hw)
 	if err != nil {
 		logger.Error(err)
 	}
 
 	labels["op"] = "insert"
-	msg = "inserting into DB"
 	fn = func() error { return s.db.InsertIntoDB(ctx, string(data)) }
 
 	metrics.CacheTotals.With(labels).Inc()
@@ -263,7 +262,7 @@ func (s *server) Delete(ctx context.Context, in *hardware.DeleteRequest) (*hardw
 
 	var fn func() error
 	labels["op"] = "delete"
-	msg := "deleting into DB"
+	const msg = "deleting into DB"
 	fn = func() error { return s.db.DeleteFromDB(ctx, in.Id) }
 
 	metrics.CacheTotals.With(labels).Inc()

--- a/grpc-server/template.go
+++ b/grpc-server/template.go
@@ -19,9 +19,8 @@ func (s *server) CreateTemplate(ctx context.Context, in *template.WorkflowTempla
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
-	msg := ""
+	const msg = "creating a new Template"
 	labels["op"] = "createtemplate"
-	msg = "creating a new Template"
 	id, _ := uuid.NewUUID()
 	fn := func() error { return s.db.CreateTemplate(ctx, in.Name, in.Data, id) }
 
@@ -51,9 +50,8 @@ func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*tem
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
-	msg := ""
+	const msg = "getting a template"
 	labels["op"] = "get"
-	msg = "getting a template"
 
 	fn := func() (string, string, error) { return s.db.GetTemplate(ctx, in.Id) }
 	metrics.CacheTotals.With(labels).Inc()
@@ -81,9 +79,8 @@ func (s *server) DeleteTemplate(ctx context.Context, in *template.GetRequest) (*
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
-	msg := ""
+	const msg = "deleting a template"
 	labels["op"] = "delete"
-	msg = "deleting a template"
 	fn := func() error { return s.db.DeleteTemplate(ctx, in.Id) }
 
 	metrics.CacheTotals.With(labels).Inc()
@@ -142,9 +139,8 @@ func (s *server) UpdateTemplate(ctx context.Context, in *template.WorkflowTempla
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
-	msg := ""
+	const msg = "updating a template"
 	labels["op"] = "updatetemplate"
-	msg = "updating a template"
 	fn := func() error { return s.db.UpdateTemplate(ctx, in.Name, in.Data, uuid.MustParse(in.Id)) }
 
 	metrics.CacheTotals.With(labels).Inc()

--- a/grpc-server/template.go
+++ b/grpc-server/template.go
@@ -22,14 +22,13 @@ func (s *server) CreateTemplate(ctx context.Context, in *template.WorkflowTempla
 	const msg = "creating a new Template"
 	labels["op"] = "createtemplate"
 	id, _ := uuid.NewUUID()
-	fn := func() error { return s.db.CreateTemplate(ctx, in.Name, in.Data, id) }
 
 	metrics.CacheTotals.With(labels).Inc()
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
 	logger.Info(msg)
-	err := fn()
+	err := s.db.CreateTemplate(ctx, in.Name, in.Data, id)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
 		l := logger
@@ -53,13 +52,12 @@ func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*tem
 	const msg = "getting a template"
 	labels["op"] = "get"
 
-	fn := func() (string, string, error) { return s.db.GetTemplate(ctx, in.Id) }
 	metrics.CacheTotals.With(labels).Inc()
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
 	logger.Info(msg)
-	n, d, err := fn()
+	n, d, err := s.db.GetTemplate(ctx, in.Id)
 	logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
@@ -81,14 +79,13 @@ func (s *server) DeleteTemplate(ctx context.Context, in *template.GetRequest) (*
 
 	const msg = "deleting a template"
 	labels["op"] = "delete"
-	fn := func() error { return s.db.DeleteTemplate(ctx, in.Id) }
 
 	metrics.CacheTotals.With(labels).Inc()
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
 	logger.Info(msg)
-	err := fn()
+	err := s.db.DeleteTemplate(ctx, in.Id)
 	logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
@@ -141,14 +138,13 @@ func (s *server) UpdateTemplate(ctx context.Context, in *template.WorkflowTempla
 
 	const msg = "updating a template"
 	labels["op"] = "updatetemplate"
-	fn := func() error { return s.db.UpdateTemplate(ctx, in.Name, in.Data, uuid.MustParse(in.Id)) }
 
 	metrics.CacheTotals.With(labels).Inc()
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
 	logger.Info(msg)
-	err := fn()
+	err := s.db.UpdateTemplate(ctx, in.Name, in.Data, uuid.MustParse(in.Id))
 	logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -30,9 +30,9 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 	labels := prometheus.Labels{"method": "CreateWorkflow", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
-	msg := ""
+
+	const msg = "creating a new workflow"
 	labels["op"] = "createworkflow"
-	msg = "creating a new workflow"
 	id, err := uuid.NewUUID()
 	if err != nil {
 		return &workflow.CreateResponse{}, err
@@ -82,9 +82,8 @@ func (s *server) GetWorkflow(ctx context.Context, in *workflow.GetRequest) (*wor
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
-	msg := ""
+	const msg = "getting a workflow"
 	labels["op"] = "get"
-	msg = "getting a workflow"
 
 	fn := func() (db.Workflow, error) { return s.db.GetWorkflow(ctx, in.Id) }
 	metrics.CacheTotals.With(labels).Inc()
@@ -124,10 +123,9 @@ func (s *server) DeleteWorkflow(ctx context.Context, in *workflow.GetRequest) (*
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
-	msg := ""
+	const msg = "deleting a workflow"
 	labels["op"] = "delete"
 	l := logger.With("workflowID", in.GetId())
-	msg = "deleting a workflow"
 	fn := func() error {
 		// update only if not in running state
 		return s.db.DeleteWorkflow(ctx, in.Id, workflow.State_value[workflow.State_RUNNING.String()])
@@ -195,9 +193,8 @@ func (s *server) GetWorkflowContext(ctx context.Context, in *workflow.GetRequest
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
-	msg := ""
+	const msg = "getting a workflow"
 	labels["op"] = "get"
-	msg = "getting a workflow"
 
 	fn := func() (*workflowpb.WorkflowContext, error) { return s.db.GetWorkflowContexts(ctx, in.Id) }
 	metrics.CacheTotals.With(labels).Inc()

--- a/http-server/http_handlers.go
+++ b/http-server/http_handlers.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"github.com/tinkerbell/tink/protos/hardware"
 	"github.com/tinkerbell/tink/pkg"
+	"github.com/tinkerbell/tink/protos/hardware"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/protos/protoc.sh
+++ b/protos/protoc.sh
@@ -6,3 +6,4 @@ for proto in hardware packet template workflow; do
 	echo "Generating ${proto}.pb.go..."
 	protoc -I ./ -I ./common/ -I "$GOPATH"/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis "${proto}/${proto}.proto" --go_out=plugins=grpc:./ --grpc-gateway_out=logtostderr=true:.
 done
+goimports -w .

--- a/protos/workflow/workflow.pb.go
+++ b/protos/workflow/workflow.pb.go
@@ -8,6 +8,9 @@ package workflow
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
@@ -16,8 +19,6 @@ import (
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
## Description

This PR cleans up some code that stood out as pretty weird when I was reading through it. Some simple function calls were being wrapped in a local var and then called via it. This is pretty odd since we can just as easily call the underlying function. Along the way I cleaned up the `msg` variable definitions from being done in multiple lines into just one as a const to better reflect how its actually used.

## How Has This Been Tested?
Still compiles, tests pass.