### PR TITLE
Changed UUID package

### DIFF
--- a/cmd/tink-cli/cmd/hardware/commands.go
+++ b/cmd/tink-cli/cmd/hardware/commands.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/jedib0t/go-pretty/table"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +26,7 @@ func verifyUUIDs(args []string) error {
 		return errors.New("requires at least one id")
 	}
 	for _, arg := range args {
-		if _, err := uuid.FromString(arg); err != nil {
+		if _, err := uuid.Parse(arg); err != nil {
 			return fmt.Errorf("invalid uuid: %s", arg)
 		}
 	}

--- a/cmd/tink-cli/cmd/template/delete.go
+++ b/cmd/tink-cli/cmd/template/delete.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/template"
@@ -21,7 +21,7 @@ var deleteCmd = &cobra.Command{
 			return fmt.Errorf("%v requires an argument", c.UseLine())
 		}
 		for _, arg := range args {
-			if _, err := uuid.FromString(arg); err != nil {
+			if _, err := uuid.Parse(arg); err != nil {
 				return fmt.Errorf("invalid uuid: %s", arg)
 			}
 		}

--- a/cmd/tink-cli/cmd/template/get.go
+++ b/cmd/tink-cli/cmd/template/get.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/template"
@@ -21,7 +21,7 @@ var getCmd = &cobra.Command{
 			return fmt.Errorf("%v requires an argument", c.UseLine())
 		}
 		for _, arg := range args {
-			if _, err := uuid.FromString(arg); err != nil {
+			if _, err := uuid.Parse(arg); err != nil {
 				return fmt.Errorf("invalid uuid: %s", arg)
 			}
 		}

--- a/cmd/tink-cli/cmd/template/update.go
+++ b/cmd/tink-cli/cmd/template/update.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/template"
@@ -31,7 +31,7 @@ var updateCmd = &cobra.Command{
 			return fmt.Errorf("%v requires argument", c.UseLine())
 		}
 		for _, arg := range args {
-			if _, err := uuid.FromString(arg); err != nil {
+			if _, err := uuid.Parse(arg); err != nil {
 				return fmt.Errorf("invalid uuid: %s", arg)
 			}
 		}

--- a/cmd/tink-cli/cmd/workflow/commands.go
+++ b/cmd/tink-cli/cmd/workflow/commands.go
@@ -3,7 +3,7 @@ package workflow
 import (
 	"fmt"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +11,7 @@ import (
 var SubCommands []*cobra.Command
 
 func validateID(id string) error {
-	if _, err := uuid.FromString(id); err != nil {
+	if _, err := uuid.Parse(id); err != nil {
 		return fmt.Errorf("invalid uuid: %s", id)
 	}
 	return nil

--- a/cmd/tink-cli/cmd/workflow/data.go
+++ b/cmd/tink-cli/cmd/workflow/data.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/workflow"
@@ -27,7 +27,7 @@ var dataCmd = &cobra.Command{
 			return fmt.Errorf("%v requires an argument", c.UseLine())
 		}
 		for _, arg := range args {
-			if _, err := uuid.FromString(arg); err != nil {
+			if _, err := uuid.Parse(arg); err != nil {
 				return fmt.Errorf("invalid uuid: %s", arg)
 			}
 		}

--- a/cmd/tink-cli/cmd/workflow/delete.go
+++ b/cmd/tink-cli/cmd/workflow/delete.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/workflow"
@@ -21,7 +21,7 @@ var deleteCmd = &cobra.Command{
 			return fmt.Errorf("%v requires an argument", c.UseLine())
 		}
 		for _, arg := range args {
-			if _, err := uuid.FromString(arg); err != nil {
+			if _, err := uuid.Parse(arg); err != nil {
 				return fmt.Errorf("invalid uuid: %s", arg)
 			}
 		}

--- a/db/db.go
+++ b/db/db.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	pb "github.com/tinkerbell/tink/protos/workflow"
 )
 

--- a/db/mock/template.go
+++ b/db/mock/template.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 type template struct {

--- a/db/mock/workflow.go
+++ b/db/mock/workflow.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"github.com/tinkerbell/tink/db"
 	pb "github.com/tinkerbell/tink/protos/workflow"
 )

--- a/db/template.go
+++ b/db/template.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 )
 
 // CreateTemplate creates a new workflow template

--- a/db/workflow.go
+++ b/db/workflow.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	"github.com/tinkerbell/tink/pkg"
 	pb "github.com/tinkerbell/tink/protos/workflow"
 )
@@ -118,7 +118,7 @@ func insertActionList(ctx context.Context, db *sql.DB, yamlData string, id uuid.
 		} else if workerID == "" {
 			return fmt.Errorf("hardware mentioned with reference %s not found", task.WorkerAddr)
 		}
-		workerUID, err := uuid.FromString(workerID)
+		workerUID, err := uuid.Parse(workerID)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/go-openapi/strfmt v0.19.3 // indirect
 	github.com/golang/protobuf v1.4.2
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
@@ -27,14 +28,11 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/rollbar/rollbar-go v1.0.2 // indirect
-	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.1
-	github.com/spf13/afero v1.1.2
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
-	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
@@ -187,8 +189,6 @@ github.com/rollbar/rollbar-go v1.0.2 h1:uA3+z0jq6ka9WUUt9VX/xuiQZXZyWRoeKvkhVvLO
 github.com/rollbar/rollbar-go v1.0.2/go.mod h1:AcFs5f0I+c71bpHlXNNDbOWJiKwjFDtISeXco0L5PKQ=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=

--- a/grpc-server/template.go
+++ b/grpc-server/template.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	uuid "github.com/satori/go.uuid"
 	"github.com/tinkerbell/tink/db"
 	"github.com/tinkerbell/tink/metrics"
 	"github.com/tinkerbell/tink/protos/template"
@@ -22,7 +22,7 @@ func (s *server) CreateTemplate(ctx context.Context, in *template.WorkflowTempla
 	msg := ""
 	labels["op"] = "createtemplate"
 	msg = "creating a new Template"
-	id := uuid.NewV4()
+	id, _ := uuid.NewUUID()
 	fn := func() error { return s.db.CreateTemplate(ctx, in.Name, in.Data, id) }
 
 	metrics.CacheTotals.With(labels).Inc()
@@ -145,7 +145,7 @@ func (s *server) UpdateTemplate(ctx context.Context, in *template.WorkflowTempla
 	msg := ""
 	labels["op"] = "updatetemplate"
 	msg = "updating a template"
-	fn := func() error { return s.db.UpdateTemplate(ctx, in.Name, in.Data, uuid.FromStringOrNil(in.Id)) }
+	fn := func() error { return s.db.UpdateTemplate(ctx, in.Name, in.Data, uuid.MustParse(in.Id)) }
 
 	metrics.CacheTotals.With(labels).Inc()
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -7,9 +7,9 @@ import (
 	"strconv"
 	"text/template"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	uuid "github.com/satori/go.uuid"
 	"github.com/tinkerbell/tink/db"
 	"github.com/tinkerbell/tink/metrics"
 	"github.com/tinkerbell/tink/protos/workflow"
@@ -33,7 +33,7 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 	msg := ""
 	labels["op"] = "createworkflow"
 	msg = "creating a new workflow"
-	id := uuid.NewV4()
+	id, _ := uuid.NewUUID()
 	fn := func() error {
 		wf := db.Workflow{
 			ID:       id.String(),

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -33,7 +33,10 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 	msg := ""
 	labels["op"] = "createworkflow"
 	msg = "creating a new workflow"
-	id, _ := uuid.NewUUID()
+	id, err := uuid.NewUUID()
+	if err != nil {
+		return &workflow.CreateResponse{}, err
+	}
 	fn := func() error {
 		wf := db.Workflow{
 			ID:       id.String(),
@@ -57,7 +60,7 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 	defer timer.ObserveDuration()
 
 	logger.Info(msg)
-	err := fn()
+	err = fn()
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
 		l := logger


### PR DESCRIPTION
## Description

The PR changes UUID package from `github.com/satori/go.uuid` to `to github.com/google/uuid`. 

## Why is this needed

The package `github.com/satori/go.uuid` is not actively maintained anymore and will eventually be marked as deprecated.
References:
- [NewV4: non-random uuid](https://github.com/satori/go.uuid/issues/73)
- [PSA: This repo is dead](https://github.com/satori/go.uuid/issues/103)
- [Add deprecation notice in favor of github.com/gofrs/uuid and archive this repo](https://github.com/satori/go.uuid/issues/84)
 
## How Has This Been Tested?

CI and Tests pass.

## How are existing users impacted? What migration steps/scripts do we need?

No impact.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
