### PR TITLE
Tink CLI now flags an error if template ID does not exist, while creating a workflow

### DIFF
--- a/db/mock/mock.go
+++ b/db/mock/mock.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/tinkerbell/tink/db"
 	pb "github.com/tinkerbell/tink/protos/workflow"
 )
 
 // DB is the mocked implementation of Database interface
 type DB struct {
+	// workflow
+	CreateWorkflowFunc               func(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error
 	GetfromWfDataTableFunc           func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error)
 	InsertIntoWfDataTableFunc        func(ctx context.Context, req *pb.UpdateWorkflowDataRequest) error
 	GetWorkflowMetadataFunc          func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error)
@@ -18,4 +22,7 @@ type DB struct {
 	GetWorkflowActionsFunc           func(ctx context.Context, wfID string) (*pb.WorkflowActionList, error)
 	UpdateWorkflowStateFunc          func(ctx context.Context, wfContext *pb.WorkflowContext) error
 	InsertIntoWorkflowEventTableFunc func(ctx context.Context, wfEvent *pb.WorkflowActionStatus, time time.Time) error
+
+	// template
+	GetTemplateFunc func(ctx context.Context, id string) (string, string, error)
 }

--- a/db/mock/template.go
+++ b/db/mock/template.go
@@ -37,7 +37,7 @@ func (d DB) CreateTemplate(ctx context.Context, name string, data string, id uui
 
 // GetTemplate returns a workflow template
 func (d DB) GetTemplate(ctx context.Context, id string) (string, string, error) {
-	return "", "", nil
+	return d.GetTemplateFunc(ctx, id)
 }
 
 // DeleteTemplate deletes a workflow template

--- a/db/mock/workflow.go
+++ b/db/mock/workflow.go
@@ -11,7 +11,7 @@ import (
 
 // CreateWorkflow creates a new workflow
 func (d DB) CreateWorkflow(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error {
-	return nil
+	return d.CreateWorkflowFunc(ctx, wf, data, id)
 }
 
 // InsertIntoWfDataTable : Insert ephemeral data in workflow_data table

--- a/db/template.go
+++ b/db/template.go
@@ -56,13 +56,11 @@ func (d TinkDB) GetTemplate(ctx context.Context, id string) (string, string, err
 	if err == nil {
 		return string(name), string(data), nil
 	}
-
 	if err != sql.ErrNoRows {
 		err = errors.Wrap(err, "SELECT")
 		logger.Error(err)
 	}
-
-	return "", "", nil
+	return "", "", err
 }
 
 // DeleteTemplate deletes a workflow template

--- a/grpc-server/workflow_test.go
+++ b/grpc-server/workflow_test.go
@@ -1,0 +1,112 @@
+package grpcserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/tinkerbell/tink/db"
+	"github.com/tinkerbell/tink/db/mock"
+	"github.com/tinkerbell/tink/protos/workflow"
+)
+
+const (
+	templateID   = "e29b6444-1de7-4a69-bf25-6ea4ae869005"
+	hw           = `{"device_1": "08:00:27:00:00:01"}`
+	templateData = `version: "0.1"
+name: hello_world_workflow
+global_timeout: 600
+tasks:
+  - name: "hello world"
+    worker: "{{.device_1}}"
+    actions:
+    - name: "hello_world"
+      image: hello-world
+      timeout: 60`
+)
+
+func TestCreateWorkflow(t *testing.T) {
+	type (
+		args struct {
+			db                     mock.DB
+			wfTemplate, wfHardware string
+		}
+		want struct {
+			expectedError bool
+		}
+	)
+	testCases := map[string]struct {
+		args args
+		want want
+	}{
+		"FailedToGetTempalte": {
+			args: args{
+				db: mock.DB{
+					GetTemplateFunc: func(ctx context.Context, id string) (string, string, error) {
+						return "", "", errors.New("failed to get template")
+					},
+				},
+				wfTemplate: templateID,
+				wfHardware: hw,
+			},
+			want: want{
+				expectedError: true,
+			},
+		},
+		"FailedCreatingWorkflow": {
+			args: args{
+				db: mock.DB{
+					GetTemplateFunc: func(ctx context.Context, id string) (string, string, error) {
+						return "", templateData, nil
+					},
+					CreateWorkflowFunc: func(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error {
+						return errors.New("failed to create a workfow")
+					},
+				},
+				wfTemplate: templateID,
+				wfHardware: hw,
+			},
+			want: want{
+				expectedError: true,
+			},
+		},
+		"SuccessCreatingWorkflow": {
+			args: args{
+				db: mock.DB{
+					GetTemplateFunc: func(ctx context.Context, id string) (string, string, error) {
+						return "", templateData, nil
+					},
+					CreateWorkflowFunc: func(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error {
+						return nil
+					},
+				},
+				wfTemplate: templateID,
+				wfHardware: hw,
+			},
+			want: want{
+				expectedError: false,
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			s := testServer(tc.args.db)
+			res, err := s.CreateWorkflow(context.TODO(), &workflow.CreateRequest{
+				Hardware: tc.args.wfHardware,
+				Template: tc.args.wfTemplate,
+			})
+			if err != nil {
+				assert.Error(t, err)
+				assert.Empty(t, res)
+				assert.True(t, tc.want.expectedError)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotEmpty(t, res)
+			assert.False(t, tc.want.expectedError)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Return error if no template is found for the provided template ID.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #282 

## How Has This Been Tested?

By attempting to create a workflow with non-existing and existing workflow ID.

## How are existing users impacted? What migration steps/scripts do we need?

Fixes a bug.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
