### PR TITLE
tink worker command line args

### DIFF
--- a/cmd/tink-worker/cmd/root.go
+++ b/cmd/tink-worker/cmd/root.go
@@ -78,13 +78,13 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 		},
 	}
 
-	rootCmd.Flags().Duration("retry-interval", defaultRetryInterval, "Retry interval in seconds")
+	rootCmd.Flags().Duration("retry-interval", defaultRetryInterval, "Retry interval in seconds (RETRY_INTERVAL)")
 
-	rootCmd.Flags().Duration("timeout", time.Duration(defaultTimeoutMinutes*time.Minute), "Max duration to wait for worker to complete")
+	rootCmd.Flags().Duration("timeout", time.Duration(defaultTimeoutMinutes*time.Minute), "Max duration to wait for worker to complete (TIMEOUT)")
 
-	rootCmd.Flags().Int("max-retry", defaultRetryCount, "Maximum number of retries to attempt")
+	rootCmd.Flags().Int("max-retry", defaultRetryCount, "Maximum number of retries to attempt (MAX_RETRY)")
 
-	rootCmd.Flags().Int64("max-file-size", defaultMaxFileSize, "Maximum file size in bytes")
+	rootCmd.Flags().Int64("max-file-size", defaultMaxFileSize, "Maximum file size in bytes (MAX_FILE_SIZE)")
 
 	// rootCmd.Flags().String("log-level", "info", "Sets the worker log level (panic, fatal, error, warn, info, debug, trace)")
 
@@ -94,24 +94,24 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 		}
 	}
 
-	rootCmd.Flags().StringP("id", "i", "", "Sets the worker id")
+	rootCmd.Flags().StringP("id", "i", "", "Sets the worker id (ID)")
 	must(rootCmd.MarkFlagRequired("id"))
 
-	rootCmd.Flags().StringP("docker-registry", "r", "", "Sets the Docker registry")
+	rootCmd.Flags().StringP("docker-registry", "r", "", "Sets the Docker registry (DOCKER_REGISTRY)")
 	must(rootCmd.MarkFlagRequired("docker-registry"))
 
-	rootCmd.Flags().StringP("registry-username", "u", "", "Sets the registry username")
+	rootCmd.Flags().StringP("registry-username", "u", "", "Sets the registry username (REGISTRY_USERNAME)")
 	must(rootCmd.MarkFlagRequired("registry-username"))
 
-	rootCmd.Flags().StringP("registry-password", "p", "", "Sets the registry-password")
+	rootCmd.Flags().StringP("registry-password", "p", "", "Sets the registry-password (REGISTRY_PASSWORD)")
 	must(rootCmd.MarkFlagRequired("registry-password"))
 
 	return rootCmd
 }
 
 // createViper creates a Viper object configured to read in configuration files
-// (from various paths with content type specific filename extensions) and load
-// environment variables that start with TINK_WORKER.
+// (from various paths with content type specific filename extensions) and loads
+// environment variables.
 func createViper(logger log.Logger) (*viper.Viper, error) {
 	v := viper.New()
 	v.AutomaticEnv()

--- a/cmd/tink-worker/cmd/root.go
+++ b/cmd/tink-worker/cmd/root.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/packethost/pkg/log"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/tinkerbell/tink/client"
+	"github.com/tinkerbell/tink/cmd/tink-worker/internal"
+	pb "github.com/tinkerbell/tink/protos/workflow"
+	"google.golang.org/grpc"
+)
+
+const (
+	retryIntervalDefault        = 3
+	retryCountDefault           = 3
+	defaultMaxFileSize    int64 = 10485760 //10MB ~= 10485760Bytes
+	defaultTimeoutMinutes       = 60
+)
+
+// NewRootCommand creates a new Tink Worker Cobra root command
+func NewRootCommand(version string, logger log.Logger) *cobra.Command {
+	must := func(err error) {
+		if err != nil {
+			logger.Fatal(err)
+		}
+	}
+
+	rootCmd := &cobra.Command{
+		Use:     "tink-worker",
+		Short:   "Tink Worker",
+		Version: version,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			viper, err := createViper()
+			if err != nil {
+				return err
+			}
+			return applyViper(viper, cmd)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			retryInterval, _ := cmd.PersistentFlags().GetDuration("retry-interval")
+			retries, _ := cmd.PersistentFlags().GetInt("retries")
+			// TODO(displague) is log-level no longer useful?
+			// logLevel, _ := cmd.PersistentFlags().GetString("log-level")
+			workerID, _ := cmd.PersistentFlags().GetString("id")
+			maxFileSize, _ := cmd.PersistentFlags().GetInt64("max-file-size")
+			timeOut, _ := cmd.PersistentFlags().GetDuration("timeout")
+			user, _ := cmd.PersistentFlags().GetString("registry-username")
+			pwd, _ := cmd.PersistentFlags().GetString("registry-password")
+			registry, _ := cmd.PersistentFlags().GetString("docker-registry")
+
+			logger.With("version", version).Info("starting")
+			if setupErr := client.Setup(); setupErr != nil {
+				return setupErr
+			}
+
+			ctx := context.Background()
+			if timeOut > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, timeOut)
+				defer cancel()
+			}
+
+			conn, err := tryClientConnection(logger, retryInterval, retries)
+			if err != nil {
+				return err
+			}
+			rClient := pb.NewWorkflowSvcClient(conn)
+
+			regConn := internal.NewRegistryConnDetails(registry, user, pwd, logger)
+			worker := internal.NewWorker(rClient, regConn, logger, registry, retries, retryInterval, maxFileSize)
+
+			err = worker.ProcessWorkflowActions(ctx, workerID)
+			if err != nil {
+				return errors.Wrap(err, "worker Finished with error")
+			}
+			return nil
+		},
+	}
+
+	rootCmd.PersistentFlags().Duration("retry-interval", retryIntervalDefault, "Retry interval in seconds")
+
+	rootCmd.PersistentFlags().Duration("timeout", time.Duration(defaultTimeoutMinutes*time.Minute), "Max duration to wait for worker to complete")
+
+	rootCmd.PersistentFlags().Int("max-retry", retryCountDefault, "Maximum number of retries to attempt")
+
+	rootCmd.PersistentFlags().Int64("max-file-size", defaultMaxFileSize, "Maximum file size in bytes")
+
+	// rootCmd.PersistentFlags().String("log-level", "info", "Sets the worker log level (panic, fatal, error, warn, info, debug, trace)")
+
+	rootCmd.PersistentFlags().StringP("id", "i", "", "Sets the worker id")
+	must(rootCmd.MarkPersistentFlagRequired("id"))
+
+	rootCmd.PersistentFlags().StringP("docker-registry", "r", "", "Sets the Docker registry")
+	must(rootCmd.MarkPersistentFlagRequired("docker-registry"))
+
+	rootCmd.PersistentFlags().StringP("registry-username", "u", "", "Sets the registry username")
+	must(rootCmd.MarkPersistentFlagRequired("registry-username"))
+
+	rootCmd.PersistentFlags().StringP("registry-password", "p", "", "Sets the registry-password")
+	must(rootCmd.MarkPersistentFlagRequired("registry-password"))
+
+	return rootCmd
+}
+
+// createViper creates a Viper object configured to read in configuration files
+// (from various paths with content type specific filename extensions) and load
+// environment variables that start with TINK_WORKER.
+func createViper() (*viper.Viper, error) {
+	v := viper.New()
+	v.AutomaticEnv()
+	v.SetConfigName("tink-worker")
+	v.AddConfigPath("/etc/tinkerbell")
+	v.AddConfigPath(".")
+	v.SetEnvPrefix("TINK_WORKER")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	// If a config file is found, read it in.
+	if err := v.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return nil, err
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "Using config file:", v.ConfigFileUsed())
+	}
+
+	return v, nil
+}
+
+func applyViper(v *viper.Viper, cmd *cobra.Command) error {
+	errors := []error{}
+
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
+				errors = append(errors, err)
+				return
+			}
+		}
+	})
+
+	if len(errors) > 0 {
+		errs := []string{}
+		for _, err := range errors {
+			errs = append(errs, err.Error())
+		}
+		return fmt.Errorf(strings.Join(errs, ", "))
+	}
+
+	return nil
+}
+
+func tryClientConnection(logger log.Logger, retryInterval time.Duration, retries int) (*grpc.ClientConn, error) {
+	for ; retries > 0; retries-- {
+		c, err := client.GetConnection()
+		if err != nil {
+			logger.With("error", err, "duration", retryInterval).Info("failed to connect, sleeping before retrying")
+			<-time.After(retryInterval * time.Second)
+			continue
+		}
+
+		return c, nil
+	}
+	return nil, fmt.Errorf("retries exceeded")
+}

--- a/cmd/tink-worker/internal/action.go
+++ b/cmd/tink-worker/internal/action.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"bufio"

--- a/cmd/tink-worker/internal/action.go
+++ b/cmd/tink-worker/internal/action.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	errContextClosed   = "failed to wait for container, context closed"
 	errCreateContainer = "failed to create container"
 	errFailedToWait    = "failed to wait for completion of action"
 	errFailedToRunCmd  = "failed to run on-timeout command"

--- a/cmd/tink-worker/internal/action.go
+++ b/cmd/tink-worker/internal/action.go
@@ -1,14 +1,9 @@
 package internal
 
 import (
-	"bufio"
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-	"time"
+	"path"
+	"path/filepath"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -18,199 +13,48 @@ import (
 	pb "github.com/tinkerbell/tink/protos/workflow"
 )
 
-var (
-	registry string
-	cli      *client.Client
-)
-
 const (
+	errContextClosed   = "failed to wait for container, context closed"
 	errCreateContainer = "failed to create container"
-	errRemoveContainer = "failed to remove container"
 	errFailedToWait    = "failed to wait for completion of action"
 	errFailedToRunCmd  = "failed to run on-timeout command"
 
 	infoWaitFinished = "wait finished for failed or timeout container"
 )
 
-func executeAction(ctx context.Context, action *pb.WorkflowAction, wfID string) (pb.ActionState, error) {
-	l := logger.With("workflowID", wfID, "workerID", action.GetWorkerId(), "actionName", action.GetName(), "actionImage", action.GetImage())
-	err := pullActionImage(ctx, action)
-	if err != nil {
-		return pb.ActionState_ACTION_IN_PROGRESS, errors.Wrap(err, "DOCKER PULL")
-	}
-	id, err := createContainer(ctx, l, action, action.Command, wfID)
-	if err != nil {
-		return pb.ActionState_ACTION_IN_PROGRESS, errors.Wrap(err, "DOCKER CREATE")
-	}
-	l.With("containerID", id, "command", action.GetOnTimeout()).Info("container created")
-	// Setting time context for action
-	timeCtx := ctx
-	if action.Timeout > 0 {
-		var cancel context.CancelFunc
-		timeCtx, cancel = context.WithTimeout(ctx, time.Duration(action.Timeout)*time.Second)
-		defer cancel()
-	}
-	err = startContainer(timeCtx, l, id)
-	if err != nil {
-		return pb.ActionState_ACTION_IN_PROGRESS, errors.Wrap(err, "DOCKER RUN")
-	}
-
-	failedActionStatus := make(chan pb.ActionState)
-
-	//capturing logs of action container in a go-routine
-	go captureLogs(ctx, id)
-
-	status, err := waitContainer(timeCtx, id)
-	if err != nil {
-		rerr := removeContainer(ctx, l, id)
-		if rerr != nil {
-			rerr = errors.Wrap(rerr, errRemoveContainer)
-			l.With("containerID", id).Error(rerr)
-			return status, rerr
-		}
-		return status, errors.Wrap(err, "DOCKER_WAIT")
-	}
-	rerr := removeContainer(ctx, l, id)
-	if rerr != nil {
-		return status, errors.Wrap(rerr, "DOCKER_REMOVE")
-	}
-	l.With("status", status.String()).Info("container removed")
-	if status != pb.ActionState_ACTION_SUCCESS {
-		if status == pb.ActionState_ACTION_TIMEOUT && action.OnTimeout != nil {
-			id, err = createContainer(ctx, l, action, action.OnTimeout, wfID)
-			if err != nil {
-				l.Error(errors.Wrap(err, errCreateContainer))
-			}
-			l.With("containerID", id, "status", status.String(), "command", action.GetOnTimeout()).Info("container created")
-			failedActionStatus := make(chan pb.ActionState)
-			go captureLogs(ctx, id)
-			go waitFailedContainer(ctx, id, failedActionStatus)
-			err = startContainer(ctx, l, id)
-			if err != nil {
-				l.Error(errors.Wrap(err, errFailedToRunCmd))
-			}
-			onTimeoutStatus := <-failedActionStatus
-			l.With("status", onTimeoutStatus).Info("action timeout")
-		} else {
-			if action.OnFailure != nil {
-				id, err = createContainer(ctx, l, action, action.OnFailure, wfID)
-				if err != nil {
-					l.Error(errors.Wrap(err, errFailedToRunCmd))
-				}
-				l.With("containerID", id, "actionStatus", status.String(), "command", action.GetOnFailure()).Info("container created")
-				go captureLogs(ctx, id)
-				go waitFailedContainer(ctx, id, failedActionStatus)
-				err = startContainer(ctx, l, id)
-				if err != nil {
-					l.Error(errors.Wrap(err, errFailedToRunCmd))
-				}
-				onFailureStatus := <-failedActionStatus
-				l.With("status", onFailureStatus).Info("action failed")
-			}
-		}
-		l.Info(infoWaitFinished)
-		if err != nil {
-			rerr := removeContainer(ctx, l, id)
-			if rerr != nil {
-				l.Error(errors.Wrap(rerr, errRemoveContainer))
-			}
-			l.Error(errors.Wrap(err, errFailedToWait))
-		}
-		rerr = removeContainer(ctx, l, id)
-		if rerr != nil {
-			l.Error(errors.Wrap(rerr, errRemoveContainer))
-		}
-	}
-	l.With("status", status).Info("action container exited")
-	return status, nil
-}
-
-func captureLogs(ctx context.Context, id string) {
-	reader, err := cli.ContainerLogs(context.Background(), id, types.ContainerLogsOptions{
-		ShowStdout: true,
-		ShowStderr: true,
-		Follow:     true,
-		Timestamps: false,
-	})
-	if err != nil {
-		panic(err)
-	}
-	defer reader.Close()
-
-	scanner := bufio.NewScanner(reader)
-	for scanner.Scan() {
-		fmt.Println(scanner.Text())
-	}
-}
-
-func pullActionImage(ctx context.Context, action *pb.WorkflowAction) error {
-	user := os.Getenv("REGISTRY_USERNAME")
-	pwd := os.Getenv("REGISTRY_PASSWORD")
-	if user == "" || pwd == "" {
-		return errors.New("required REGISTRY_USERNAME and REGISTRY_PASSWORD")
-	}
-
-	authConfig := types.AuthConfig{
-		Username:      user,
-		Password:      pwd,
-		ServerAddress: registry,
-	}
-	encodedJSON, err := json.Marshal(authConfig)
-	if err != nil {
-		return errors.Wrap(err, "DOCKER AUTH")
-	}
-	authStr := base64.URLEncoding.EncodeToString(encodedJSON)
-
-	out, err := cli.ImagePull(ctx, registry+"/"+action.GetImage(), types.ImagePullOptions{RegistryAuth: authStr})
-	if err != nil {
-		return errors.Wrap(err, "DOCKER PULL")
-	}
-	defer out.Close()
-	if _, err := io.Copy(os.Stdout, out); err != nil {
-		return err
-	}
-	return nil
-}
-
-func createContainer(ctx context.Context, l log.Logger, action *pb.WorkflowAction, cmd []string, wfID string) (string, error) {
+func (w *Worker) createContainer(ctx context.Context, cmd []string, wfID string, action *pb.WorkflowAction) (string, error) {
+	registry := w.registry
 	config := &container.Config{
-		Image:        registry + "/" + action.GetImage(),
+		Image:        path.Join(registry, action.GetImage()),
 		AttachStdout: true,
 		AttachStderr: true,
+		Cmd:          cmd,
 		Tty:          true,
 		Env:          action.GetEnvironment(),
 	}
-	if cmd != nil {
-		config.Cmd = cmd
-	}
 
-	wfDir := dataDir + string(os.PathSeparator) + wfID
+	wfDir := filepath.Join(dataDir, wfID)
 	hostConfig := &container.HostConfig{
 		Privileged: true,
 		Binds:      []string{wfDir + ":/workflow"},
 	}
 	hostConfig.Binds = append(hostConfig.Binds, action.GetVolumes()...)
-	l.With("command", cmd).Info("creating container")
-	resp, err := cli.ContainerCreate(ctx, config, hostConfig, nil, action.GetName())
+	w.logger.With("command", cmd).Info("creating container")
+	resp, err := w.registryClient.ContainerCreate(ctx, config, hostConfig, nil, action.GetName())
 	if err != nil {
 		return "", errors.Wrap(err, "DOCKER CREATE")
 	}
 	return resp.ID, nil
 }
 
-func startContainer(ctx context.Context, l log.Logger, id string) error {
+func startContainer(ctx context.Context, l log.Logger, cli *client.Client, id string) error {
 	l.With("containerID", id).Debug("starting container")
-	err := cli.ContainerStart(ctx, id, types.ContainerStartOptions{})
-	if err != nil {
-		return errors.Wrap(err, "DOCKER START")
-	}
-	return nil
+	return errors.Wrap(cli.ContainerStart(ctx, id, types.ContainerStartOptions{}), "DOCKER START")
 }
 
-func waitContainer(ctx context.Context, id string) (pb.ActionState, error) {
+func waitContainer(ctx context.Context, cli *client.Client, id string) (pb.ActionState, error) {
 	// Inspect whether the container is in running state
-	_, err := cli.ContainerInspect(ctx, id)
-	if err != nil {
+	if _, err := cli.ContainerInspect(ctx, id); err != nil {
 		return pb.ActionState_ACTION_FAILED, nil
 	}
 
@@ -230,7 +74,7 @@ func waitContainer(ctx context.Context, id string) (pb.ActionState, error) {
 	}
 }
 
-func waitFailedContainer(ctx context.Context, id string, failedActionStatus chan pb.ActionState) {
+func waitFailedContainer(ctx context.Context, l log.Logger, cli *client.Client, id string, failedActionStatus chan pb.ActionState) {
 	// send API call to wait for the container completion
 	wait, errC := cli.ContainerWait(ctx, id, container.WaitConditionNotRunning)
 
@@ -241,12 +85,15 @@ func waitFailedContainer(ctx context.Context, id string, failedActionStatus chan
 		}
 		failedActionStatus <- pb.ActionState_ACTION_FAILED
 	case err := <-errC:
-		logger.Error(err)
+		l.Error(err)
 		failedActionStatus <- pb.ActionState_ACTION_FAILED
+	case <-ctx.Done():
+		l.Error(ctx.Err())
+		failedActionStatus <- pb.ActionState_ACTION_TIMEOUT
 	}
 }
 
-func removeContainer(ctx context.Context, l log.Logger, id string) error {
+func removeContainer(ctx context.Context, l log.Logger, cli *client.Client, id string) error {
 	// create options for removing container
 	opts := types.ContainerRemoveOptions{
 		Force:         true,
@@ -256,21 +103,5 @@ func removeContainer(ctx context.Context, l log.Logger, id string) error {
 	l.With("containerID", id).Info("removing container")
 
 	// send API call to remove the container
-	err := cli.ContainerRemove(ctx, id, opts)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func initializeDockerClient() (*client.Client, error) {
-	registry = os.Getenv("DOCKER_REGISTRY")
-	if registry == "" {
-		return nil, errors.New("required DOCKER_REGISTRY")
-	}
-	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		return nil, errors.Wrap(err, "DOCKER CLIENT")
-	}
-	return c, nil
+	return cli.ContainerRemove(ctx, id, opts)
 }

--- a/cmd/tink-worker/internal/registry.go
+++ b/cmd/tink-worker/internal/registry.go
@@ -1,0 +1,71 @@
+package internal
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/packethost/pkg/log"
+	"github.com/pkg/errors"
+)
+
+// RegistryConnDetails are the connection details for accessing a Docker
+// registry and logging activities
+type RegistryConnDetails struct {
+	registry,
+	user,
+	pwd string
+	logger log.Logger
+}
+
+// NewRegistryConnDetails creates a new RegistryConnDetails
+func NewRegistryConnDetails(registry, user, pwd string, logger log.Logger) *RegistryConnDetails {
+	return &RegistryConnDetails{
+		registry: registry,
+		user:     user,
+		pwd:      pwd,
+		logger:   logger,
+	}
+}
+
+// NewClient uses the RegistryConnDetails to create a new Docker Client
+func (r *RegistryConnDetails) NewClient() (*client.Client, error) {
+	if r.registry == "" {
+		return nil, errors.New("required DOCKER_REGISTRY")
+	}
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+
+	if err != nil {
+		return nil, errors.Wrap(err, "DOCKER CLIENT")
+	}
+
+	return c, nil
+}
+
+// pullImage outputs to stdout the contents of the requested image (relative to the registry)
+func (r *RegistryConnDetails) pullImage(ctx context.Context, cli *client.Client, image string) error {
+	authConfig := types.AuthConfig{
+		Username:      r.user,
+		Password:      r.pwd,
+		ServerAddress: r.registry,
+	}
+	encodedJSON, err := json.Marshal(authConfig)
+	if err != nil {
+		return errors.Wrap(err, "DOCKER AUTH")
+	}
+	authStr := base64.URLEncoding.EncodeToString(encodedJSON)
+
+	out, err := cli.ImagePull(ctx, r.registry+"/"+image, types.ImagePullOptions{RegistryAuth: authStr})
+	if err != nil {
+		return errors.Wrap(err, "DOCKER PULL")
+	}
+	defer out.Close()
+	if _, err := io.Copy(os.Stdout, out); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/tink-worker/internal/worker.go
+++ b/cmd/tink-worker/internal/worker.go
@@ -1,4 +1,4 @@
-package main
+package internal
 
 import (
 	"context"

--- a/cmd/tink-worker/internal/worker.go
+++ b/cmd/tink-worker/internal/worker.go
@@ -98,8 +98,7 @@ func (w *Worker) execute(ctx context.Context, wfID string, action *pb.WorkflowAc
 	l := w.logger.With("workflowID", wfID, "workerID", action.GetWorkerId(), "actionName", action.GetName(), "actionImage", action.GetImage())
 
 	cli := w.registryClient
-	err := w.regConn.pullImage(ctx, cli, action.GetImage())
-	if err != nil {
+	if err := w.regConn.pullImage(ctx, cli, action.GetImage()); err != nil {
 		return pb.ActionState_ACTION_IN_PROGRESS, errors.Wrap(err, "DOCKER PULL")
 	}
 	id, err := w.createContainer(ctx, action.Command, wfID, action)

--- a/cmd/tink-worker/main.go
+++ b/cmd/tink-worker/main.go
@@ -2,103 +2,31 @@ package main
 
 import (
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/packethost/pkg/log"
-	"github.com/pkg/errors"
-	"github.com/tinkerbell/tink/client"
-	pb "github.com/tinkerbell/tink/protos/workflow"
-	"google.golang.org/grpc"
+	"github.com/tinkerbell/tink/cmd/tink-worker/cmd"
 )
 
 const (
-	retryIntervalDefault = 3
-	retryCountDefault    = 3
-
-	serviceKey           = "github.com/tinkerbell/tink"
-	invalidRetryInterval = "invalid RETRY_INTERVAL, using default (seconds)"
-	invalidMaxRetry      = "invalid MAX_RETRY, using default"
-
-	errWorker = "worker finished with error"
+	serviceKey = "github.com/tinkerbell/tink"
 )
 
 var (
-	rClient       pb.WorkflowSvcClient
-	retryInterval time.Duration
-	retries       int
-	logger        log.Logger
-
 	// version is set at build time
 	version = "devel"
 )
 
 func main() {
-	log, err := log.Init(serviceKey)
+	logger, err := log.Init(serviceKey)
 	if err != nil {
 		panic(err)
 	}
-	logger = log
+
 	defer logger.Close()
-	log.With("version", version).Info("starting")
-	setupRetry()
-	if setupErr := client.Setup(); setupErr != nil {
-		log.Error(setupErr)
+
+	rootCmd := cmd.NewRootCommand(version, logger)
+
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
-	}
-	conn, err := tryClientConnection()
-	if err != nil {
-		log.Error(err)
-		os.Exit(1)
-	}
-	rClient = pb.NewWorkflowSvcClient(conn)
-	err = processWorkflowActions(rClient)
-	if err != nil {
-		log.Error(errors.Wrap(err, errWorker))
-	}
-}
-
-func tryClientConnection() (*grpc.ClientConn, error) {
-	var err error
-	for r := 1; r <= retries; r++ {
-		c, e := client.GetConnection()
-		if e != nil {
-			err = e
-			logger.With("error", err, "duration", retryInterval).Info("failed to connect, sleeping before retrying")
-			<-time.After(retryInterval * time.Second)
-			continue
-		}
-		return c, nil
-	}
-	return nil, err
-}
-
-func setupRetry() {
-	interval := os.Getenv("RETRY_INTERVAL")
-	if interval == "" {
-		logger.With("default", retryIntervalDefault).Info("RETRY_INTERVAL not set")
-		retryInterval = retryIntervalDefault
-	} else {
-		interval, err := time.ParseDuration(interval)
-		if err != nil {
-			logger.With("default", retryIntervalDefault).Info(invalidRetryInterval)
-			retryInterval = retryIntervalDefault
-		} else {
-			retryInterval = interval
-		}
-	}
-
-	maxRetry := os.Getenv("MAX_RETRY")
-	if maxRetry == "" {
-		logger.With("default", retryCountDefault).Info("MAX_RETRY not set")
-		retries = retryCountDefault
-	} else {
-		max, err := strconv.Atoi(maxRetry)
-		if err != nil {
-			logger.With("default", retryCountDefault).Info(invalidMaxRetry)
-			retries = retryCountDefault
-		} else {
-			retries = max
-		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -25,12 +25,16 @@ require (
 	github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.3.0
+	github.com/prometheus/common v0.7.0
+	github.com/rollbar/rollbar-go v1.0.2 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20200616145509-8d140a17f351
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013

--- a/http-server/http_handlers.go
+++ b/http-server/http_handlers.go
@@ -23,6 +23,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// RegisterHardwareServiceHandlerFromEndpoint serves Hardware requests at the
+// given endpoint over GRPC
 func RegisterHardwareServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	conn, err := grpc.Dial(endpoint, opts...)
 	if err != nil {
@@ -214,6 +216,8 @@ func RegisterHardwareServiceHandlerFromEndpoint(ctx context.Context, mux *runtim
 	return nil
 }
 
+// RegisterTemplateHandlerFromEndpoint serves Template requests at the given
+// endpoint over GRPC
 func RegisterTemplateHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	conn, err := grpc.Dial(endpoint, opts...)
 	if err != nil {
@@ -347,6 +351,8 @@ func RegisterTemplateHandlerFromEndpoint(ctx context.Context, mux *runtime.Serve
 	return nil
 }
 
+// RegisterWorkflowSvcHandlerFromEndpoint serves Workflow requests at the given
+// endpoint over GRPC
 func RegisterWorkflowSvcHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
 	conn, err := grpc.Dial(endpoint, opts...)
 	if err != nil {

--- a/http-server/http_handlers.go
+++ b/http-server/http_handlers.go
@@ -8,7 +8,8 @@ import (
 	"net/http"
 	tt "text/template"
 
-	// nolint:staticcheck SA1019 We will do it later
+	// nolint:staticcheck
+	// SA1019 We will do it later
 	"github.com/golang/protobuf/jsonpb"
 
 	"github.com/tinkerbell/tink/protos/template"


### PR DESCRIPTION
## Description

This PR makes most constants and environment variables for tink-worker configurable from the command line, environment variables, and falls back to a `.tinkerbell.yaml` (`worker-id: 1234`) (or .json) file.

```
$ ./tink-worker -w 212
Error: required flag(s) "docker-registry", "registry-password", "registry-username" not set
Usage:
  tink-worker [flags]

Flags:
  -r, --docker-registry string     Sets the Docker registry (DOCKER_REGISTRY)
  -h, --help                       help for tink-worker
  -s, --max-file-size int          Maximum file size in bytes (MAX_FILE_SIZE) (default 10485760)
  -m, --max-retry int              Maximum number of retries to attempt (MAX_RETRY) (default 3)
  -p, --registry-password string   Sets the registry-password (REGISTRY_PASSWORD)
  -u, --registry-username string   Sets the registry username (REGISTRY_USERNAME)
  -i, --retry-interval duration    Retry interval in seconds (RETRY_INTERVAL) (default 3ns)
  -v, --version                    version for tink-worker
  -w, --worker-id string           Sets the worker id (WORKER_ID)
  -l, --worker-log-level string    Sets the worker log level (panic, fatal, error, warn, info, debug, trace) (WORKER_LOG_LEVEL) (default "info")
  -t, --worker-timeout duration    Max duration to wait for worker to complete (WORKER_TIMEOUT)
```

Notably, `TINKERBELL_CERT_URL` lookups are checked from a client that is defined in a parent package. This variable has not been made configurable in the same way.

This is similar in spirit to #266 

Considerable refactoring was done to clean up the use of global variables. The `internal` pkg contains a `Worker` and `RegistryConnDetails` struct which are context bags for the methods that needed these global variables. I imagine we will continue to evolve these types to find a better shape.



## Why is this needed

When run from various environments, users may have an easier time manipulating either configuration files, command line arguments, or the environment. Also, by defining these variables with cobra/viper, users can leverage `--help` and we can eventually use this to generate man pages, shell auto-completions, and markdown docs.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

## Known Bugs

* `--help` does not include the environment variable hints which are shown when invalid args are supplied 🤔  (these hints are generated at runtime, we could just move them into the text description)

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
