### PR TITLE
Fixed #291 : tink template commands exit in case of template file does not exist

### DIFF
--- a/cmd/tink-cli/cmd/template/create.go
+++ b/cmd/tink-cli/cmd/template/create.go
@@ -43,7 +43,7 @@ cat /tmp/example.tmpl | tink template create -n example`,
 		} else {
 			f, err := os.Open(filePath)
 			if err != nil {
-				log.Println(err)
+				log.Fatal(err)
 			}
 			reader = f
 		}
@@ -51,8 +51,7 @@ cat /tmp/example.tmpl | tink template create -n example`,
 		data := readAll(reader)
 		if data != nil {
 			if err := tryParseTemplate(string(data)); err != nil {
-				log.Println(err)
-				return
+				log.Fatal(err)
 			}
 			createTemplate(data)
 		}
@@ -62,7 +61,7 @@ cat /tmp/example.tmpl | tink template create -n example`,
 func readAll(reader io.Reader) []byte {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 	return data
 }
@@ -86,8 +85,7 @@ func createTemplate(data []byte) {
 	req := template.WorkflowTemplate{Name: templateName, Data: string(data)}
 	res, err := client.TemplateClient.CreateTemplate(context.Background(), &req)
 	if err != nil {
-		log.Println(err)
-		return
+		log.Fatal(err)
 	}
 	fmt.Println("Created Template: ", res.Id)
 }

--- a/cmd/tink-cli/cmd/template/update.go
+++ b/cmd/tink-cli/cmd/template/update.go
@@ -52,8 +52,7 @@ func updateTemplate(id string) {
 		data := readTemplateData()
 		if data != "" {
 			if err := tryParseTemplate(data); err != nil {
-				log.Println(err)
-				return
+				log.Fatal(err)
 			}
 			req.Data = data
 		}
@@ -72,13 +71,13 @@ func updateTemplate(id string) {
 func readTemplateData() string {
 	f, err := os.Open(filePath)
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 	defer f.Close()
 
 	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 	return string(data)
 }


### PR DESCRIPTION

Signed-off-by: parauliya <aman@infracloud.io>

## Description

1. tink template create command should fail in case of any failures
2. tink template update command should fail in case of any failures

## Why is this needed

Fixes: #291 

## How Has This Been Tested?
Tested manually using vagrant

## How are existing users impacted? What migration steps/scripts do we need?
No impact on existing users.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
