### PR TITLE
Terraform is not a required tool anymore

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,5 @@ mkShell {
     pythonPackages.codespell
     shfmt
     shellcheck
-    terraform
   ];
 }


### PR DESCRIPTION
Removed terraform from nix-shell because it is not required anymore.
