### PR TITLE
Disable codecov path

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
## Description

I am not sure we are ready to get this granularity, all our PRs are
failing for that reason and I don't feel strong enough to push other
people or myself to make the patch itself green.

There is still a check that looks at diff in coverage for all project, but not for the commit itself

## Why is this needed

Coverage is important but sanity is more.

## How Has This Been Tested?

## How are existing users impacted? What migration steps/scripts do we need?

none

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
