### PR TITLE
[tink-worker] Fix use and defaulting of the max-retry flag

### DIFF
--- a/cmd/tink-worker/cmd/root.go
+++ b/cmd/tink-worker/cmd/root.go
@@ -39,7 +39,7 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			retryInterval, _ := cmd.Flags().GetDuration("retry-interval")
-			retries, _ := cmd.Flags().GetInt("retries")
+			retries, _ := cmd.Flags().GetInt("max-retry")
 			// TODO(displague) is log-level no longer useful?
 			// logLevel, _ := cmd.Flags().GetString("log-level")
 			workerID, _ := cmd.Flags().GetString("id")


### PR DESCRIPTION
## Description

Previously we were trying to fetch the wrong flag value when configuring retries for tink-worker, this PR fixes that.

## Why is this needed

## How Has This Been Tested?
I tested this in my Tilt/kind setup

## How are existing users impacted? What migration steps/scripts do we need?

Fixes issues with using the latest tink-worker for e2e testing/deployment.

It doesn't require any changes for users or require any additional migration.

