### PR TITLE
Tink CLI errors now end with a newline

### DIFF
--- a/cmd/tink-cli/main.go
+++ b/cmd/tink-cli/main.go
@@ -12,7 +12,7 @@ var version = "devel"
 
 func main() {
 	if err := cmd.Execute(version); err != nil {
-		fmt.Fprint(os.Stderr, err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,6 @@ require (
 	github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.3.0
-	github.com/prometheus/common v0.7.0
-	github.com/rollbar/rollbar-go v1.0.2 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20200616145509-8d140a17f351
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v1.0.0
@@ -34,7 +32,6 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/sys v0.0.0-20200331124033-c3d80250170d // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013


### PR DESCRIPTION
## Description

With this change, the CLI errors will now end with a newline. Therefore, making it easier for a user to read the error message.

## Why is this needed

Fixes: #336 

## How Has This Been Tested?

Tested on the local vagrant setup.

```
/ # tink hardware id
Error: requires at least one id
Usage:
  tink hardware id [flags]

Examples:
tink hardware id 224ee6ab-ad62-4070-a900-ed816444cec0 cb76ae54-93e9-401c-a5b2-d455bb3800b1

Flags:
  -h, --help   help for id

Global Flags:
  -f, --facility string   used to build grpc and http urls

requires at least one id
/ # 
```
## How are existing users impacted? What migration steps/scripts do we need?

It's easier to read the error message now.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
