### PR TITLE
Migrating docker action from v1 to v2 in GH Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,11 +49,15 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: ./ci-checks.sh
   docker-images:
-    env:
-      CGO_ENABLED: 0
     runs-on: ubuntu-latest
     needs: [validation]
     steps:
+    - name: Docker Image Tag for Sha
+      id: docker-image-tag
+      run: |
+        echo ::set-output name=tink-server-tags::quay.io/tinkerbell/tink:latest,quay.io/tinkerbell/tink:sha-${GITHUB_SHA::8}
+        echo ::set-output name=tink-cli-tags::quay.io/tinkerbell/tink-cli:latest,quay.io/tinkerbell/tink-cli:sha-${GITHUB_SHA::8}
+        echo ::set-output name=tink-worker-tags::quay.io/tinkerbell/tink-worker:latest,quay.io/tinkerbell/tink-worker:sha-${GITHUB_SHA::8}
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Download tink-cli binary
@@ -77,36 +81,35 @@ jobs:
       run: chmod +x  ./cmd/tink-cli/tink-cli
     - name: set tink-server permission
       run: chmod +x  ./cmd/tink-server/tink-server
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: quay.io/tinkerbell/tink
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        repository: tinkerbell/tink
-        path: ./cmd/tink-server/
-        registry: quay.io
+        context: ./cmd/tink-server/
+        file: ./cmd/tink-server/Dockerfile
+        cache-from: type=registry,ref=quay.io/tinkerbell/tink:latest
         push: ${{ startsWith(github.ref, 'refs/heads/master') }}
-        tags: latest
-        tag_with_sha: true
+        tags: ${{ steps.docker-image-tag.outputs.tink-server-tags }}
     - name: quay.io/tinkerbell/tink-cli
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        repository: tinkerbell/tink-cli
-        path: ./cmd/tink-cli/
-        registry: quay.io
+        context: ./cmd/tink-cli/
+        file: ./cmd/tink-cli/Dockerfile
+        cache-from: type=registry,ref=quay.io/tinkerbell/tink-cli:latest
         push: ${{ startsWith(github.ref, 'refs/heads/master') }}
-        tags: latest
-        tag_with_sha: true
+        tags: ${{ steps.docker-image-tag.outputs.tink-cli-tags }}
     - name: quay.io/tinkerbell/tink-worker
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@v2
       with:
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        repository: tinkerbell/tink-worker
-        path: ./cmd/tink-worker/
-        registry: quay.io
+        context: ./cmd/tink-worker/
+        file: ./cmd/tink-worker/Dockerfile
+        cache-from: type=registry,ref=quay.io/tinkerbell/tink-worker:latest
         push: ${{ startsWith(github.ref, 'refs/heads/master') }}
-        tags: latest
-        tag_with_sha: true
+        tags: ${{ steps.docker-image-tag.outputs.tink-worker-tags }}


### PR DESCRIPTION
Signed-off-by: parauliya <aman@infracloud.io>

## Description

Migrating docker action from v1 to v2 in Github action workflow

## Why is this needed

Fixes: #339 

## How Has This Been Tested?
All the GH Action should pass in this PR.

## How are existing users impacted? What migration steps/scripts do we need?
No impact.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
