### PR TITLE
ENG-9317 Fix concurrent workflow create bug

### DIFF
--- a/db/workflow.go
+++ b/db/workflow.go
@@ -33,7 +33,7 @@ var (
 
 // CreateWorkflow creates a new workflow
 func (d TinkDB) CreateWorkflow(ctx context.Context, wf Workflow, data string, id uuid.UUID) error {
-	tx, err := d.instance.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	tx, err := d.instance.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
 	if err != nil {
 		return errors.Wrap(err, "BEGIN transaction")
 	}


### PR DESCRIPTION
Signed-off-by: Kelly Deng <kelly@packet.com>

## Description

<!--- Please describe what this PR is going to change -->
Lowers the transaction isolation level from `serializable` to `repeatable read` as `serializable` appears to be too overly strict.

## Why is this needed

<!--- Link to issue you have raised -->
When creating several workflows in parallel, an error is returned:
```
rpc error: code = Unknown desc = Failed to workflow: inserting e3ea67ac-2d5d-45ce-8cb3-fca42abc896f, INSERT in to workflow: pq: could not serialize access due to read/write dependencies among transactions
```

### example:
```
/ # cat inputs | parallel
Created Workflow:  7c8404ee-52a7-49a9-bacc-57ae9171e8c1
2020/10/14 15:08:18 rpc error: code = Unknown desc = Failed to workflow: inserting e3ea67ac-2d5d-45ce-8cb3-fca42abc896f, INSERT in to workflow: pq: could not serialize access due to read/write dependencies among transactions
Created Workflow:  6981c47b-443b-4d69-932b-4e6b6d1ce678
2020/10/14 15:08:18 rpc error: code = Unknown desc = Failed to workflow: inserting 48de21ee-5bac-4498-96c4-21c4ad46ae33, INSERT in to workflow: pq: could not serialize access due to read/write dependencies among transactions
Created Workflow:  a0921f77-e7f6-4aeb-8c5b-823e1d57168c
Created Workflow:  875a9033-51ce-4b5a-a786-1d3c0520eeb4
2020/10/14 15:08:18 rpc error: code = Unknown desc = Failed to insert in workflow_state: inserting 5f1a1f7c-d264-4339-b0fc-12f5fb72bd81, INSERT in to workflow_state: pq: could not serialize access due to read/write dependencies among transactions
Created Workflow:  cde501b0-51f0-4df8-9844-7c0e581a2e69
Created Workflow:  4acef5ac-5299-45ec-bbe9-56871a6fbe61
Created Workflow:  83a6dc36-bfae-456d-8b46-501e6dd16f03
```

**`inputs` file contents**
```
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
tink workflow create -t 67a0b806-6315-4a98-a56d-99fb03b30573 -r '{"device_1": "b4:96:91:5f:af:c0"}'
```

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually, using [parallel](https://www.gnu.org/software/parallel/) to run workflow create commands in parallel

Lowering the isolation level to `repeatable read` and using the same `input` file from above, the workflow create commands succeed without error:
```
/ # cat inputs | parallel
Created Workflow:  e3651718-3657-444d-93cd-a47d37d8b3df
Created Workflow:  706cb112-104a-4f2d-9996-0de9742c3633
Created Workflow:  6fada3af-f601-4463-bde3-63af3323955c
Created Workflow:  b7bf0f64-8767-4436-9cc4-68c585b47e43
Created Workflow:  5c6bc466-b2d1-4e49-af13-2ecedee81e24
Created Workflow:  3e681699-6f39-47d2-bb44-2f4c504dc1fd
Created Workflow:  661c5c0d-57bd-4dda-bd15-f2c81defb1a0
Created Workflow:  9c8e8ec4-c768-406e-b2ce-f4286ab6eb86
Created Workflow:  6099a384-442c-419b-996e-8f2e172bfab6
Created Workflow:  dec9db7b-1cf9-4b07-96f2-e52757614e04
```


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

No migration needed.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
