### PR TITLE
Quay login only works if commit is in master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
     - name: Login to quay.io
       uses: docker/login-action@v1
+      if: ${{ startsWith(github.ref, 'refs/heads/master') }}
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
GitHub Action environment variables gets passed to PR only if they
starts from a branch that is local, so fork does not get a QUAY PASSOWRD
and USERNAME, this is to avoid security issue.

GitHub is working at it but for now that's what we have.

We push images to Quay only if the commit is in master, but during a
re-work of the GitHub Action we login all the time. And that's a bug.

Fixes CI for https://github.com/tinkerbell/tink/pull/342
