### PR TITLE
Fix concurrent workflow create bug by unique index

### DIFF
--- a/db/migration/202010221010-add-unique-index.go
+++ b/db/migration/202010221010-add-unique-index.go
@@ -1,0 +1,12 @@
+package migration
+
+import migrate "github.com/rubenv/sql-migrate"
+
+func Get202010221010() *migrate.Migration {
+        return &migrate.Migration{
+                Id: "202010221010-add-unique-index",
+                Up: []string{`
+CREATE UNIQUE INDEX IF NOT EXISTS uidx_workflow_worker_map ON workflow_worker_map (workflow_id, worker_id);
+`},
+        }
+}

--- a/db/migration/migration.go
+++ b/db/migration/migration.go
@@ -6,6 +6,7 @@ func GetMigrations() *migrate.MemoryMigrationSource {
 	return &migrate.MemoryMigrationSource{
 		Migrations: []*migrate.Migration{
 			Get202009171251(),
+			Get202010221010(),
 		},
 	}
 }


### PR DESCRIPTION
## Description

When multiple process concurrently create workflow, the code to access workflow_worker_map is not concurrent safe. This PR fix this issue. 

## Why is this needed

During workflow creation, new rows may be add to table `workflow_worker_map` in the same transaction. The original design use ` INSERT ... SELECT`. This doesn't work concurrently with SERRIELIZABLE isolation.

Fixes: #

- Create unique index on workflow_worker_map table
- Use `INSERT ... ON CONFLICT DO NOTHING;` to avoid table lock.

## How Has This Been Tested?

Manually as https://github.com/tinkerbell/tink/pull/342.

## How are existing users impacted? What migration steps/scripts do we need?

- No impact
- database migrate to 202010221010-add-unique-index.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
