### PR TITLE
Raise create work flow isolation back to Serializable

### DIFF
--- a/db/workflow.go
+++ b/db/workflow.go
@@ -33,7 +33,7 @@ var (
 
 // CreateWorkflow creates a new workflow
 func (d TinkDB) CreateWorkflow(ctx context.Context, wf Workflow, data string, id uuid.UUID) error {
-	tx, err := d.instance.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelRepeatableRead})
+	tx, err := d.instance.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return errors.Wrap(err, "BEGIN transaction")
 	}

--- a/deploy/db/tinkerbell-init.sql
+++ b/deploy/db/tinkerbell-init.sql
@@ -68,6 +68,8 @@ CREATE TABLE IF NOT EXISTS workflow_worker_map (
         , worker_id UUID NOT NULL
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS uidx_workflow_worker_map ON workflow_worker_map (workflow_id, worker_id);
+
 CREATE TABLE IF NOT EXISTS workflow_data (
         workflow_id UUID NOT NULL
         , version INT


### PR DESCRIPTION
## Description

After PR #346 merged, raise back isolation level from repeatable read to serializable.
Also add create unique index ddl to tinkerbell-init.sql.

## How Has This Been Tested?

- Manually

## How are existing users impacted? What migration steps/scripts do we need?

- No

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
