### PR TITLE
Fix fmt in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       with:
         go-version: '1.14.6'
     - name: goimports
-      run: go get golang.org/x/tools/cmd/goimports && goimports .
+      run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
     - name: go vet
       run: go vet ./...
     - name: golangci-lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.14.6'
-    - name: go fmt
-      run: go fmt ./...
+    - name: goimports
+      run: go get golang.org/x/tools/cmd/goimports && goimports .
     - name: go vet
       run: go vet ./...
     - name: golangci-lint

--- a/cmd/tink-cli/cmd/hardware/commands.go
+++ b/cmd/tink-cli/cmd/hardware/commands.go
@@ -6,15 +6,12 @@ import (
 	"log"
 	"os"
 
-	"github.com/tinkerbell/tink/pkg"
-
-	"github.com/tinkerbell/tink/protos/hardware"
-
-	"github.com/jedib0t/go-pretty/table"
-
 	"github.com/google/uuid"
+	"github.com/jedib0t/go-pretty/table"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/tinkerbell/tink/pkg"
+	"github.com/tinkerbell/tink/protos/hardware"
 )
 
 // SubCommands holds the sub commands for template command

--- a/cmd/tink-cli/cmd/hardware/id.go
+++ b/cmd/tink-cli/cmd/hardware/id.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/tinkerbell/tink/pkg"
-
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
+	"github.com/tinkerbell/tink/pkg"
 	"github.com/tinkerbell/tink/protos/hardware"
 )
 

--- a/cmd/tink-cli/cmd/hardware/push.go
+++ b/cmd/tink-cli/cmd/hardware/push.go
@@ -11,10 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/tinkerbell/tink/pkg"
-
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
+	"github.com/tinkerbell/tink/pkg"
 	"github.com/tinkerbell/tink/protos/hardware"
 )
 

--- a/cmd/tink-cli/cmd/hardware/watch.go
+++ b/cmd/tink-cli/cmd/hardware/watch.go
@@ -10,10 +10,9 @@ import (
 	"log"
 	"sync"
 
-	"github.com/tinkerbell/tink/pkg"
-
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
+	"github.com/tinkerbell/tink/pkg"
 	"github.com/tinkerbell/tink/protos/hardware"
 )
 

--- a/db/migration/202010221010-add-unique-index.go
+++ b/db/migration/202010221010-add-unique-index.go
@@ -3,10 +3,10 @@ package migration
 import migrate "github.com/rubenv/sql-migrate"
 
 func Get202010221010() *migrate.Migration {
-        return &migrate.Migration{
-                Id: "202010221010-add-unique-index",
-                Up: []string{`
+	return &migrate.Migration{
+		Id: "202010221010-add-unique-index",
+		Up: []string{`
 CREATE UNIQUE INDEX IF NOT EXISTS uidx_workflow_worker_map ON workflow_worker_map (workflow_id, worker_id);
 `},
-        }
+	}
 }

--- a/grpc-server/tinkerbell_test.go
+++ b/grpc-server/tinkerbell_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/tinkerbell/tink/db"
 	"github.com/tinkerbell/tink/db/mock"
 	"github.com/tinkerbell/tink/metrics"

--- a/http-server/http_handlers.go
+++ b/http-server/http_handlers.go
@@ -9,14 +9,12 @@ import (
 	tt "text/template"
 
 	"github.com/golang/protobuf/jsonpb" // nolint:staticcheck
-
-	"github.com/tinkerbell/tink/protos/template"
-	"github.com/tinkerbell/tink/protos/workflow"
-
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"github.com/tinkerbell/tink/pkg"
 	"github.com/tinkerbell/tink/protos/hardware"
+	"github.com/tinkerbell/tink/protos/template"
+	"github.com/tinkerbell/tink/protos/workflow"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/http-server/http_handlers_test.go
+++ b/http-server/http_handlers_test.go
@@ -4,23 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-
-	grpcRuntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/packethost/pkg/log"
-
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/test/bufconn"
-
 	"testing"
 
+	grpcRuntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/tink/protos/hardware"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 const bufSize = 1024 * 1024

--- a/http-server/http_server.go
+++ b/http-server/http_server.go
@@ -12,13 +12,12 @@ import (
 	"runtime"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
 	grpcRuntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 var (

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,7 @@ mkShell {
     git
     gnumake
     go
+    gotools
     jq
     nodePackages.prettier
     pythonPackages.codespell


### PR DESCRIPTION
## Description

Ensures all our code is `go fmt` (really `goimports` clean) by checking in CI and failing if there's a change.

## Why is this needed

Fixes: #350 

## How Has This Been Tested?

`goimports` is happy and tests aren't affected.


## How are existing users impacted? What migration steps/scripts do we need?

No impact.
