### PR TITLE
Fix tink-cli

### DIFF
--- a/cmd/tink-cli/Dockerfile
+++ b/cmd/tink-cli/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/myapp
 RUN make cli
 
 FROM alpine:3.11
-ENTRYPOINT ["/usr/bin/tink-cli"]
+CMD sleep infinity
+
 RUN apk add --no-cache --update --upgrade ca-certificates
-COPY --from=0 /usr/myapp/cmd/tink-cli/tink-cli /usr/bin/tink-cli
+COPY --from=0 /usr/myapp/cmd/tink-cli/tink-cli /usr/bin/tink


### PR DESCRIPTION
Signed-off-by: Kelly Deng <kelly@packet.com>

## Description

<!--- Please describe what this PR is going to change -->
Fixes the `tink-cli`'s Dockerfile

## Why is this needed

<!--- Link to issue you have raised -->
The recent merge of PR https://github.com/tinkerbell/tink/pull/323 introduced a bug where the `tink-cli` container would keep restarting on create. 

```
root@tink02-provisioner:~/tink/deploy# docker ps
CONTAINER ID        IMAGE                                                                   COMMAND                  CREATED             STATUS                        PORTS                                  NAMES
0733f33c8ad8        quay.io/tinkerbell/tink-cli:latest                                      "/usr/bin/tink-cli"      6 seconds ago       Restarting (0) 1 second ago                                          deploy_tink-cli_1
```

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested manually

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
