### PR TITLE
Fix login to quay only in master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Login to quay.io
       uses: docker/login-action@v1
+      if: ${{ startsWith(github.ref, 'refs/heads/master') }}
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
The login to Quay has to happen only for commits landing to master
