### PR TITLE
Fix compose now that we build binaries in Docker

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,7 +2,8 @@ version: "2.1"
 services:
   tink-server:
     build:
-      context: ../cmd/tink-server
+      context: ../
+      dockerfile: ../cmd/tink-server/Dockerfile
     restart: unless-stopped
     environment:
       FACILITY: ${FACILITY:-onprem}
@@ -34,7 +35,8 @@ services:
 
   tink-server-migration:
     build:
-      context: ../cmd/tink-server
+      context: ../
+      dockerfile: ../cmd/tink-server/Dockerfile
     restart: on-failure
     environment:
       ONLY_MIGRATION: "true"
@@ -73,7 +75,8 @@ services:
 
   tink-cli:
     build:
-      context: ../cmd/tink-cli
+      context: ../
+      dockerfile: ../cmd/tink-cli/Dockerfile
     restart: unless-stopped
     environment:
       TINKERBELL_GRPC_AUTHORITY: 127.0.0.1:42113

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   tink-server:
     build:
       context: ../
-      dockerfile: ../cmd/tink-server/Dockerfile
+      dockerfile: cmd/tink-server/Dockerfile
     restart: unless-stopped
     environment:
       FACILITY: ${FACILITY:-onprem}
@@ -36,7 +36,7 @@ services:
   tink-server-migration:
     build:
       context: ../
-      dockerfile: ../cmd/tink-server/Dockerfile
+      dockerfile: cmd/tink-server/Dockerfile
     restart: on-failure
     environment:
       ONLY_MIGRATION: "true"
@@ -76,7 +76,7 @@ services:
   tink-cli:
     build:
       context: ../
-      dockerfile: ../cmd/tink-cli/Dockerfile
+      dockerfile: cmd/tink-cli/Dockerfile
     restart: unless-stopped
     environment:
       TINKERBELL_GRPC_AUTHORITY: 127.0.0.1:42113


### PR DESCRIPTION
Tested it with the local vagrant setup:

```
vagrant@provisioner:/vagrant/deploy$ docker-compose ps
             Name                           Command                  State                             Ports                       
-----------------------------------------------------------------------------------------------------------------------------------
deploy_boots_1                   /usr/bin/boots -dhcp-addr  ...   Up                                                               
deploy_db_1                      docker-entrypoint.sh postgres    Up (healthy)   0.0.0.0:5432->5432/tcp                            
deploy_hegel_1                   /usr/bin/hegel                   Up                                                               
deploy_nginx_1                   /docker-entrypoint.sh ngin ...   Up             192.168.1.2:80->80/tcp                            
deploy_registry_1                /entrypoint.sh /etc/docker ...   Up (healthy)                                                     
deploy_tink-cli_1                /bin/sh -c sleep infinity        Up                                                               
deploy_tink-server-migration_1   /usr/bin/tink-server             Exit 0                                                           
deploy_tink-server_1             /usr/bin/tink-server             Up (healthy)   0.0.0.0:42113->42113/tcp, 0.0.0.0:42114->42114/tcp
```