### PR TITLE
Remove hard coded role and db name from init db migration

### DIFF
--- a/db/migration/202009171251-init-database.go
+++ b/db/migration/202009171251-init-database.go
@@ -6,9 +6,6 @@ func Get202009171251() *migrate.Migration {
 	return &migrate.Migration{
 		Id: "202009171251-init-database",
 		Up: []string{`
-SET ROLE tinkerbell;
-SELECT 'CREATE DATABASE tinkerbell' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'tinkerbell');
-
 CREATE TABLE IF NOT EXISTS hardware (
 	id UUID UNIQUE
 	, inserted_at TIMESTAMPTZ

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -63,6 +63,7 @@ services:
     environment:
       POSTGRES_PASSWORD: tinkerbell
       POSTGRES_USER: tinkerbell
+      POSTGRES_DB: tinkerbell
     volumes:
       - postgres_data:/var/lib/postgresql/data:rw
     ports:


### PR DESCRIPTION
## Description

The initial database migration currently has a hard coded database name and role.  This change removes both.

## Why is this needed

This prevents us from deploying tink against a database that happens to utilize a different role or db name.
## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
