### PR TITLE
DB Package Unit Tests

### DIFF
--- a/db/common_test.go
+++ b/db/common_test.go
@@ -1,0 +1,187 @@
+// Package db - common test
+// The following file contains all the common functions for testing.
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/packethost/pkg/log"
+)
+
+var (
+	ids = testID{
+		instanceID: "da013837-a30c-237a-adfc-2d9ad69d5000",
+		hardwareID: "ce2e62ed-826f-4485-a39f-a82bb74338e2",
+		templateID: "da013837-a30c-237a-adfc-2d9ad69d5011",
+		workflowID: "b356eede-22c1-11eb-8c17-0242ac120004",
+	}
+)
+
+type hardwarePayload struct {
+	ID       string `json:"id"`
+	Metadata struct {
+		Facility struct {
+			FacilityCode string `json:"facility_code"`
+		} `json:"facility"`
+		Instance struct {
+			IPAddresses []struct {
+				Address string `json:"address"`
+			} `json:"ip_addresses"`
+		} `json:"instance"`
+		State string `json:"state"`
+	} `json:"metadata"`
+	Network struct {
+		Interfaces []struct {
+			Dhcp struct {
+				Arch string `json:"arch"`
+				IP   struct {
+					Address string `json:"address"`
+					Gateway string `json:"gateway"`
+					Netmask string `json:"netmask"`
+				} `json:"ip"`
+				Mac  string `json:"mac"`
+				Uefi bool   `json:"uefi"`
+			} `json:"dhcp"`
+			Netboot struct {
+				AllowPxe      bool `json:"allow_pxe"`
+				AllowWorkflow bool `json:"allow_workflow"`
+			} `json:"netboot"`
+		} `json:"interfaces"`
+	} `json:"network"`
+}
+
+type testArgs struct {
+	host         string
+	port         int32
+	tinkDb       *TinkDB
+	hardwareID   string
+	user         string
+	password     string
+	dbname       string
+	psqlInfo     string
+	logger       log.Logger
+	ctx          context.Context
+	instanceData string
+	hardwareData string
+	// templateData - referenced in workflow.Workflow. Formatted as yaml.
+	templateData        string
+	templateDataUpdated string
+	workflowData        Workflow
+}
+
+type testID struct {
+	workflowID string
+	instanceID string
+	hardwareID string
+	templateID string
+}
+
+func (a *testArgs) setLogger(t *testing.T) {
+	var err error
+	if a.logger, err = log.Init("github.com/tinkerbell/tink"); err != nil {
+		t.Error(err)
+	}
+}
+
+func (a *testArgs) setPsqlInfo() {
+	a.psqlInfo = fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+		a.host, a.port, a.user, a.password, a.dbname)
+	a.logger.Info(a.psqlInfo)
+}
+
+func newTestParams(t *testing.T, ids testID) *testArgs {
+	var err error
+
+	hardwareData := `{
+    "id": "` + ids.hardwareID + `",
+    "metadata": {
+      "facility": {
+        "facility_code": "onprem"
+      },
+      "instance": {
+        "ip_addresses": [{
+          "address": ""
+        }]
+      },
+      "state": ""
+    },
+    "network": {
+      "interfaces": [{
+        "dhcp": {
+          "arch": "x86_64",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "mac": "08:00:27:00:00:01",
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true
+        }
+      }]
+    }
+  }`
+	a := &testArgs{
+		ctx:        context.Background(),
+		host:       "localhost",
+		port:       5432,
+		tinkDb:     nil,
+		user:       "tinkerbell",
+		password:   "tinkerbell",
+		dbname:     "tinkerbell",
+		hardwareID: ids.hardwareID,
+		workflowData: Workflow{
+			State:    0,
+			ID:       ids.workflowID,
+			Hardware: hardwareData,
+			Template: ids.templateID,
+		},
+		hardwareData: hardwareData,
+		instanceData: ` {
+    "id": "` + ids.instanceID + `",
+    "instance": {
+      "ip_addresses": [
+      {
+        "address": "192.168.0.1"
+      }
+      ]
+    }
+    }`,
+		templateData: `
+version: "0.1"
+name: hello_world_workflow
+global_timeout: 600
+tasks:
+- name: "hello world"
+  worker: "192.168.0.1"
+  actions:
+  - name: "hello_world"
+    image: hello-world
+    timeout: 60`,
+		templateDataUpdated: `
+version: "0.2"
+name: hello_world_workflow
+global_timeout: 600
+tasks:
+- name: "hello world"
+  worker: "192.168.0.1"
+  actions:
+  - name: "hello_world"
+    image: hello-world
+    timeout: 60`,
+	}
+	////////////////////////////////////////////////////////////////////////////
+	a.setLogger(t)
+	a.setPsqlInfo()
+	a.tinkDb = Connect(a.logger)
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		panic(err)
+	}
+	return a
+}

--- a/db/hardware_test.go
+++ b/db/hardware_test.go
@@ -1,0 +1,240 @@
+// Package db - hardware tests
+// The following tests validate database functionality, using both network and
+// instance payloads. A postgres instance with the tink database schema is
+// required in order to run the following tests.
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+)
+
+// setupInsertIntoDB : inserts a single record in the hardware database.
+func setupInsertIntoDB(t *testing.T) {
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if _, err := a.tinkDb.instance.Exec("delete from hardware;"); err != nil {
+		t.Fail()
+	}
+	if err := a.tinkDb.InsertIntoDB(a.ctx, a.instanceData); err != nil {
+		t.Logf("%s", a.instanceData)
+		a.logger.Error(err)
+		t.Fail()
+	}
+	if err := a.tinkDb.InsertIntoDB(a.ctx, a.hardwareData); err != nil {
+		t.Logf("%s", a.hardwareData)
+		a.logger.Error(err)
+		t.Fail()
+	}
+}
+
+// TestGetByMac : retrieves a single record based on the MAC address provided.
+func TestGetByMac(t *testing.T) {
+	setupInsertIntoDB(t)
+	var response string
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if response, err = a.tinkDb.GetByMAC(a.ctx, "08:00:27:00:00:01"); err != nil {
+		t.Fail()
+	}
+	var expected hardwarePayload
+	if err = json.Unmarshal([]byte(a.hardwareData), &expected); err != nil {
+		t.Fail()
+	}
+	var received hardwarePayload
+	if err = json.Unmarshal([]byte(response), &received); err != nil {
+		t.Fail()
+	}
+	if fmt.Sprintf("%+v", received) != fmt.Sprintf("%+v", expected) {
+		t.Logf("\nRECIEVED: %+v\nEXPECTED: %+v", received, expected)
+		t.Fail()
+	}
+}
+
+// TestGetByIP : retrieves a single record based on the IP provided.
+func TestGetByIP(t *testing.T) {
+	setupInsertIntoDB(t)
+	var response string
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if response, err = a.tinkDb.GetByIP(a.ctx, "192.168.1.5"); err != nil {
+		t.Fail()
+	}
+	var expected hardwarePayload
+	if err = json.Unmarshal([]byte(a.hardwareData), &expected); err != nil {
+		t.Fail()
+	}
+	var received hardwarePayload
+	if err = json.Unmarshal([]byte(response), &received); err != nil {
+		t.Fail()
+	}
+	if fmt.Sprintf("%+v", received) != fmt.Sprintf("%+v", expected) {
+		t.Logf("\nRECIEVED: %+v\nEXPECTED: %+v", received, expected)
+		t.Fail()
+	}
+}
+
+// TestGetByInstanceIP : retrieves a single hardware instances based on the IP
+// provided.
+func TestGetByInstanceIP(t *testing.T) {
+	setupInsertIntoDB(t)
+	var response string
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if response, err = a.tinkDb.GetByIP(a.ctx, "192.168.0.1"); err != nil {
+		t.Fail()
+	}
+	var expected hardwarePayload
+	if err = json.Unmarshal([]byte(a.instanceData), &expected); err != nil {
+		t.Fail()
+	}
+	var received hardwarePayload
+	if err = json.Unmarshal([]byte(response), &received); err != nil {
+		t.Fail()
+	}
+	if fmt.Sprintf("%+v", received) != fmt.Sprintf("%+v", expected) {
+		t.Logf("\nRECIEVED: %+v\nEXPECTED: %+v", received, expected)
+		t.Logf("%s", response)
+		t.Fail()
+	}
+}
+
+// TestConcurrentInsertIntoDb : inserts five records concurrently and validates
+// whether or not all five records are actually committed.
+func TestConcurrentInsertIntoDb(t *testing.T) {
+	var err error
+	count := 10
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if _, err := a.tinkDb.instance.Query("delete from hardware;"); err != nil {
+		t.Fail()
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		var payload hardwarePayload
+		mac := fmt.Sprintf("A%v:A%v:A%v:A%v:A%v:A%v", rand.Intn(9), rand.Intn(9), rand.Intn(9), rand.Intn(9), rand.Intn(9), rand.Intn(9))
+		if err = json.Unmarshal([]byte(a.hardwareData), &payload); err != nil {
+			t.Fail()
+		}
+		payload.Network.Interfaces[0].Dhcp.Mac = mac
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			t.Fail()
+		}
+		payload.ID = uuid.String()
+		b, err := json.Marshal(payload)
+		t.Logf("PUSHING %s", b)
+		if err != nil {
+			t.Fail()
+		}
+		go func(data string, a *testArgs, wg *sync.WaitGroup) {
+			defer wg.Done()
+			if err := a.tinkDb.InsertIntoDB(a.ctx, data); err != nil {
+				a.logger.Error(err)
+				t.Fail()
+			}
+		}(string(b), a, &wg)
+	}
+	wg.Wait()
+	var resultRole int
+	if err = a.tinkDb.instance.QueryRow("select count(*) as count from hardware;").Scan(&resultRole); err != nil {
+		t.Fail()
+	}
+	if resultRole != count {
+		t.Errorf("MACS PUSHED: %v. \n MACS RETURNED: %v", count, resultRole)
+	}
+}
+
+// TestSerializedInsertIntoDb : inserts five records one at a time and validates
+// if all five records are actually committed.
+func TestSerializedInsertIntoDb(t *testing.T) {
+	var err error
+	count := 10
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if _, err := a.tinkDb.instance.Query("delete from hardware;"); err != nil {
+		t.Fail()
+	}
+	for i := 0; i < count; i++ {
+		var payload hardwarePayload
+		mac := fmt.Sprintf("A%v:A%v:A%v:A%v:A%v:A%v", rand.Intn(9), rand.Intn(9), rand.Intn(9), rand.Intn(9), rand.Intn(9), rand.Intn(9))
+		if err = json.Unmarshal([]byte(a.hardwareData), &payload); err != nil {
+			t.Fail()
+		}
+		payload.Network.Interfaces[0].Dhcp.Mac = mac
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			t.Fail()
+		}
+		payload.ID = uuid.String()
+		b, err := json.Marshal(payload)
+		t.Logf("PUSHING %s", b)
+		if err != nil {
+			t.Fail()
+		}
+		if err := a.tinkDb.InsertIntoDB(a.ctx, string(b)); err != nil {
+			a.logger.Error(err)
+			t.Fail()
+		}
+	}
+	var resultRole int
+	if err = a.tinkDb.instance.QueryRow("select count(*) as count from hardware;").Scan(&resultRole); err != nil {
+		t.Fail()
+	}
+	if resultRole != count {
+		t.Errorf("MACS PUSHED: %v. \n MACS RETURNED: %v", count, resultRole)
+	}
+}
+
+// TestGetByID : retrieves a single record based on the UUID provided.
+func TestGetByID(t *testing.T) {
+	setupInsertIntoDB(t)
+	var response string
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if response, err = a.tinkDb.GetByID(a.ctx, ids.hardwareID); err != nil {
+		t.Fail()
+	}
+	var expected hardwarePayload
+	if err = json.Unmarshal([]byte(a.hardwareData), &expected); err != nil {
+		t.Fail()
+	}
+	var received hardwarePayload
+	if err = json.Unmarshal([]byte(response), &received); err != nil {
+		t.Fail()
+	}
+	if fmt.Sprintf("%+v", received) != fmt.Sprintf("%+v", expected) {
+		t.Logf("\nRECIEVED: %+v\nEXPECTED: %+v", received, expected)
+		t.Fail()
+	}
+}
+
+// TestDeleteFromDb : deletes a single record based on the UUID provided.
+func TestDeleteFromDb(t *testing.T) {
+	setupInsertIntoDB(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if err = a.tinkDb.DeleteFromDB(a.ctx, ids.hardwareID); err != nil {
+		t.Fail()
+	}
+}

--- a/db/template_test.go
+++ b/db/template_test.go
@@ -1,0 +1,204 @@
+// Package db - template tests
+// The following tests validate database functionality, the instance payload.
+// A postgres instance with the tink database schema is required in order to run
+// the following tests.
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+)
+
+// TestCreateTemplate : validates the creation of a new workflow template.
+func TestCreateTemplate(t *testing.T) {
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	id, err := uuid.Parse(ids.templateID)
+	if err != nil {
+		t.Fail()
+	}
+	if _, err := a.tinkDb.instance.Exec("delete from template;"); err != nil {
+		t.Fail()
+	}
+	if err := a.tinkDb.CreateTemplate(a.ctx, "foo", a.templateData, id); err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+}
+
+// TestCreateDuplicateTemplate : creates a duplicate template with the same name.
+// This test should fail. It should only work if the original record is marked
+// for deletion.
+func TestCreateDuplicateTemplate(t *testing.T) {
+	TestCreateTemplate(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	id, err := uuid.NewUUID()
+	if err != nil {
+		t.Fail()
+	}
+	err = a.tinkDb.CreateTemplate(a.ctx, "foo", a.templateData, id)
+	if err != nil {
+		a.logger.Error(err)
+		if !strings.Contains(err.Error(), "exists") {
+			t.Error("function should return: foo already exists")
+		}
+	} else {
+		t.Error("function should return an error")
+	}
+}
+
+// TestCreateNewDuplicateTemplate : creates a duplicate template with the same
+// name, but the previous template will be marked for deletion.
+// This test should pass.
+func TestCreateNewDuplicateTemplate(t *testing.T) {
+	setupInsertIntoDB(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if err = a.tinkDb.DeleteTemplate(a.ctx, ids.templateID); err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+	id, err := uuid.NewUUID()
+	if err != nil {
+		t.Fail()
+	}
+	if err = a.tinkDb.CreateTemplate(a.ctx, "foo", a.templateData, id); err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+}
+
+// TestUpdatesTemplateOnCreate : updates an existing template if not deleted and
+// the uuid is the same.
+// This test should pass.
+func TestUpdateTemplateOnCreate(t *testing.T) {
+	TestCreateTemplate(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	id, err := uuid.Parse(ids.templateID)
+	if err != nil {
+		t.Fail()
+	}
+	if err = a.tinkDb.CreateTemplate(a.ctx, "bar", a.templateData, id); err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+}
+
+// TestConcurrentCreateTemplate : inserts five records concurrently and validates
+// whether or not all five records are actually committed.
+func TestConcurrentCreateTemplate(t *testing.T) {
+	var err error
+	count := 10
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if _, err := a.tinkDb.instance.Query("delete from template;"); err != nil {
+		t.Fail()
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		id, err := uuid.NewRandom()
+		if err != nil {
+			t.Fail()
+		}
+		label := fmt.Sprintf("temp%v", i)
+		t.Logf("PUSHING %v", i)
+		if err != nil {
+			t.Fail()
+		}
+		go func(k string, v string, a *testArgs, wg *sync.WaitGroup) {
+			defer wg.Done()
+			id, err := uuid.Parse(v)
+			if err != nil {
+				t.Fail()
+			}
+			if err := a.tinkDb.CreateTemplate(a.ctx, k, a.templateData, id); err != nil {
+				a.logger.Error(err)
+				t.Fail()
+			}
+		}(label, id.String(), a, &wg)
+	}
+	wg.Wait()
+	var resultRole int
+	if err = a.tinkDb.instance.QueryRow("select count(*) as count from template;").Scan(&resultRole); err != nil {
+		t.Fail()
+	}
+	if resultRole != count {
+		t.Error(fmt.Errorf("Tempaltes PUSHED: %v. \n MACS RETURNED: %v", count, resultRole))
+	}
+}
+
+// TestGetTemplate : validates retrieving a workflow template.
+func TestGetTemplate(t *testing.T) {
+	TestCreateTemplate(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	filter := make(map[string]string)
+	filter["name"] = "foo"
+	if _, _, _, err = a.tinkDb.GetTemplate(a.ctx, filter); err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+}
+
+// TestDeleteTemplate : validates the deletion of a template.
+func TestDeleteTemplate(t *testing.T) {
+	setupInsertIntoDB(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if err = a.tinkDb.DeleteTemplate(a.ctx, ids.templateID); err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+}
+
+// TestUpdateTemplate : validates updating a template.
+func TestUpdateTemplate(t *testing.T) {
+	TestCreateTemplate(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	id, err := uuid.Parse(ids.templateID)
+	if err != nil {
+		t.Fail()
+	}
+	filter := make(map[string]string)
+	filter["name"] = "foo"
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		t.Fail()
+	}
+	if err = a.tinkDb.UpdateTemplate(a.ctx, "foo", a.templateDataUpdated, id); err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+	_, _, received, err := a.tinkDb.GetTemplate(a.ctx, filter)
+	if err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+	if received != a.templateDataUpdated {
+		err = fmt.Errorf("EXPECTED: %s\nRECEIVED: %s", a.templateDataUpdated, received)
+		t.Error(err)
+	}
+}

--- a/db/workflow_test.go
+++ b/db/workflow_test.go
@@ -1,0 +1,232 @@
+// Package db - workflow tests
+// The following tests validate database functionality, the instance payload.
+// A postgres instance with the tink database schema is required in order to run
+// the following tests.
+package db
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	pb "github.com/tinkerbell/tink/protos/workflow"
+)
+
+// TestCreateWorkflow : validates the creation of a new workflow.
+func TestCreateWorkflow(t *testing.T) {
+	TestCreateTemplate(t)
+	setupInsertIntoDB(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	id, err := uuid.Parse(ids.templateID)
+	if err != nil {
+		t.Fail()
+	}
+	if _, err := a.tinkDb.instance.Exec(`delete from workflow;`); err != nil {
+		t.Fail()
+	}
+	if _, err := a.tinkDb.instance.Exec(`delete from workflow_event;`); err != nil {
+		t.Fail()
+	}
+	if _, err := a.tinkDb.instance.Exec(`delete from workflow_state;`); err != nil {
+		t.Fail()
+	}
+	if _, err := a.tinkDb.instance.Exec(`delete from workflow_data;`); err != nil {
+		t.Fail()
+	}
+	if err := a.tinkDb.CreateWorkflow(a.ctx, a.workflowData, a.templateData, id); err != nil {
+		t.Logf("WORKFLOW: %+v \n", a.workflowData)
+		a.logger.Error(err)
+		t.Fail()
+	}
+}
+
+// TestInsertIntoWfDataTable : validates the insert operation.
+func TestInsertIntoWfDataTable(t *testing.T) {
+	TestCreateWorkflow(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	data, err := json.Marshal(a.workflowData)
+	if err != nil {
+		t.Fail()
+	}
+	update := &pb.UpdateWorkflowDataRequest{Metadata: data, Data: data, WorkflowId: ids.templateID}
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		t.Fail()
+	}
+	if err := a.tinkDb.InsertIntoWfDataTable(a.ctx, update); err != nil {
+		a.logger.Error(err)
+		t.Fail()
+	}
+}
+
+// TestGetfromWfDataTable : validates returning workflow data.
+func TestGetfromWfDataTable(t *testing.T) {
+	TestCreateWorkflow(t)
+	var response []byte
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	req := &pb.GetWorkflowDataRequest{WorkflowId: ids.templateID}
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		t.Fail()
+	}
+	if response, err = a.tinkDb.GetfromWfDataTable(a.ctx, req); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+	t.Logf("%s", response)
+}
+
+// TestGetWorkflowMetadata : validates retrieving workflow meta data.
+func TestGetWorkflowMetadata(t *testing.T) {
+	TestCreateWorkflow(t)
+	var response []byte
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	req := &pb.GetWorkflowDataRequest{WorkflowId: ids.templateID}
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		t.Fail()
+	}
+	if response, err = a.tinkDb.GetWorkflowMetadata(a.ctx, req); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+	t.Logf("%s", response)
+}
+
+// TestGetWorkflowDataVersion : validates getting workflow data version.
+func TestGetWorkflowDataVersion(t *testing.T) {
+	TestInsertIntoWfDataTable(t)
+	var response int32
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if response, err = a.tinkDb.GetWorkflowDataVersion(a.ctx, ids.templateID); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+	expected := int32(1)
+	if expected != response {
+		t.Error(fmt.Errorf("EXPECTED: %v\nRECEIVED: %v", expected, response))
+	}
+}
+
+// TestGetWorkflowsForWorker : validates getting workflows for worker.
+func TestGetWorkflowsForWorker(t *testing.T) {
+	TestCreateWorkflow(t)
+	var response []string
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if response, err = a.tinkDb.GetWorkflowsForWorker(ids.workflowID); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+	t.Logf("%+v", response)
+}
+
+// TestGetWorkflow : validates getting workflow.
+func TestGetWorkflow(t *testing.T) {
+	TestCreateWorkflow(t)
+	var response Workflow
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if response, err = a.tinkDb.GetWorkflow(a.ctx, ids.workflowID); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+	if a.workflowData.ID != response.ID {
+		t.Errorf("EXPECTED: %v\nRECEIVED:%v", a.workflowData.ID, response.ID)
+	}
+}
+
+// TestDeleteWorkflow : validates deleting workflow.
+func TestDeleteWorkflow(t *testing.T) {
+	TestCreateWorkflow(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		t.Fail()
+	}
+	if err = a.tinkDb.DeleteWorkflow(a.ctx, ids.workflowID, int32(0)); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+}
+
+// TestUpdateWorkflow : validates updating a workflow.
+func TestUpdateWorkflow(t *testing.T) {
+	TestCreateWorkflow(t)
+	var response Workflow
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		t.Fail()
+	}
+	a.workflowData.Hardware = `{"id": "` + ids.hardwareID + `", "network": {"interfaces": [{"dhcp": {"ip": {"address": "192.168.1.6", "gateway": "192.168.1.1", "netmask": "255.255.255.248"}, "mac": "08:00:27:00:00:01", "arch": "x86_64", "uefi": false}, "netboot": {"allow_pxe": true, "allow_workflow": true}}]}, "metadata": {"state": "", "facility": {"facility_code": "onprem"}, "instance": {"ip_addresses": [{"address": ""}]}}}`
+	if err = a.tinkDb.UpdateWorkflow(a.ctx, a.workflowData, int32(0)); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+	if response, err = a.tinkDb.GetWorkflow(a.ctx, ids.workflowID); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+	if response.Hardware != a.workflowData.Hardware {
+		t.Error(fmt.Errorf("EXPECTED: %s\nRECEIVED:%s", a.workflowData.Hardware, response.Hardware))
+	}
+}
+
+// TestUpdateWorkflowState : validates updating workflow state.
+func TestUpdateWorkflowState(t *testing.T) {
+	TestCreateWorkflow(t)
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		t.Fail()
+	}
+	wfContext := &pb.WorkflowContext{WorkflowId: ids.templateID}
+	if err = a.tinkDb.UpdateWorkflowState(a.ctx, wfContext); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+}
+
+// TestGetWorkflowContexts : validates getting workflow context.
+func TestGetWorkflowContexts(t *testing.T) {
+	TestCreateWorkflow(t)
+	var response *pb.WorkflowContext
+	var err error
+	a := newTestParams(t, ids)
+	defer a.tinkDb.instance.Close()
+
+	if a.tinkDb.instance, err = sql.Open("postgres", a.psqlInfo); err != nil {
+		t.Fail()
+	}
+	if response, err = a.tinkDb.GetWorkflowContexts(a.ctx, ids.templateID); err != nil {
+		a.logger.Error(err)
+		t.Error(err)
+	}
+	t.Logf("%s", response)
+}


### PR DESCRIPTION
## Description

Unit tests for testing db package. These tests **require** the postgres container to be up and running. Failure to include this will result in failed tests.

## Why is this needed

The only unit tests in the db package are mock tests that do not validate database schema or functions embedded in database calls. These new tests validate requests against database responses. 

## How Has This Been Tested?

- Built docker postgres image
- Ran `go test -v` from within the db package.

```
=== RUN   TestConnect
~/go/src/github.com/tinkerbell/tink/db>go test -v
{"level":"info","ts":1605025139.0087209,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.0093741,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestConnect (0.00s)
=== RUN   TestInsertIntoDB
{"level":"info","ts":1605025139.0115247,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestInsertIntoDB (0.01s)
=== RUN   TestGetByMac
{"level":"info","ts":1605025139.0172408,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.0229852,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestGetByMac (0.01s)
=== RUN   TestGetByIP
{"level":"info","ts":1605025139.0251362,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.0313911,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestGetByIP (0.01s)
=== RUN   TestGetByInstanceIP
{"level":"info","ts":1605025139.0334523,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.0390992,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestGetByInstanceIP (0.01s)
=== RUN   TestConcurrentInsertIntoDb
{"level":"info","ts":1605025139.0414908,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
    hardware_test.go:140: PUSHING {"id":"0d971aec-dcdd-5689-b485-735265db8247","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"00-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
    hardware_test.go:140: PUSHING {"id":"fb5a4adc-21d9-2c56-dc8a-d58db7e61794","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"11-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
    hardware_test.go:140: PUSHING {"id":"a05cee79-8fa4-3619-bd41-87e699073639","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"22-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
    hardware_test.go:140: PUSHING {"id":"42ca7955-a0e9-8a49-0edc-74e1cc09325b","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"33-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
    hardware_test.go:140: PUSHING {"id":"891be7fe-7ab9-770d-393b-5f1572f2b406","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"44-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
--- PASS: TestConcurrentInsertIntoDb (0.01s)
=== RUN   TestSerializedInsertIntoDb
{"level":"info","ts":1605025139.0491385,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
    hardware_test.go:187: PUSHING {"id":"495fe336-ee26-f49f-598a-22332e66ffc5","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"00-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
    hardware_test.go:187: PUSHING {"id":"afff2569-3e8a-8656-26d8-dd7d043c5a4a","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"11-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
    hardware_test.go:187: PUSHING {"id":"6b742848-7e35-ef68-86c7-cefd6cd68bfb","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"22-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
    hardware_test.go:187: PUSHING {"id":"8467bea4-d701-1c96-de37-69372c36cd4f","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"33-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
    hardware_test.go:187: PUSHING {"id":"214fb166-b708-0df4-d9de-49ee7dc3ef48","metadata":{"facility":{"facility_code":"onprem"},"instance":{"ip_addresses":null},"state":""},"network":{"interfaces":[{"dhcp":{"arch":"x86_64","ip":{"address":"192.168.1.5","gateway":"192.168.1.1","netmask":"255.255.255.248"},"mac":"44-00-00-00-00-00","uefi":false},"netboot":{"allow_pxe":true,"allow_workflow":true}}]}}
--- PASS: TestSerializedInsertIntoDb (0.01s)
=== RUN   TestGetByID
{"level":"info","ts":1605025139.062928,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.0703447,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestGetByID (0.01s)
=== RUN   TestDeleteFromDb
{"level":"info","ts":1605025139.0723722,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.078004,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestDeleteFromDb (0.01s)
=== RUN   TestCreateTemplate
{"level":"info","ts":1605025139.0812051,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestCreateTemplate (0.00s)
=== RUN   TestConcurrentCreateTemplate
{"level":"info","ts":1605025139.0861146,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
    template_test.go:56: PUSHING foo4
    template_test.go:56: PUSHING foo5
    template_test.go:56: PUSHING foo1
    template_test.go:56: PUSHING foo2
    template_test.go:56: PUSHING foo3
--- PASS: TestConcurrentCreateTemplate (0.01s)
=== RUN   TestGetTemplate
{"level":"info","ts":1605025139.0942135,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1025968,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestGetTemplate (0.01s)
=== RUN   TestDeleteTemplate
{"level":"info","ts":1605025139.104913,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1107957,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestDeleteTemplate (0.01s)
=== RUN   TestUpdateTemplate
{"level":"info","ts":1605025139.1142876,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1200056,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestUpdateTemplate (0.01s)
=== RUN   TestCreateWorkflow
{"level":"info","ts":1605025139.1239328,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1286101,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1354823,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestCreateWorkflow (0.02s)
=== RUN   TestInsertIntoWfDataTable
{"level":"info","ts":1605025139.1453214,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1504803,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1563342,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1654112,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestInsertIntoWfDataTable (0.02s)
=== RUN   TestGetfromWfDataTable
{"level":"info","ts":1605025139.1692672,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1739728,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.1794631,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.191144,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
    workflow_test.go:86: 
--- PASS: TestGetfromWfDataTable (0.02s)
=== RUN   TestGetWorkflowMetadata
{"level":"info","ts":1605025139.193556,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.199337,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.207261,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.2188663,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
    workflow_test.go:105: 
--- PASS: TestGetWorkflowMetadata (0.03s)
=== RUN   TestGetWorkflowDataVersion
{"level":"info","ts":1605025139.2209892,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.2252748,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.2317948,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.2750075,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.2785532,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestGetWorkflowDataVersion (0.06s)
=== RUN   TestGetWorkflowsForWorker
{"level":"info","ts":1605025139.2818756,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.2859907,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.2915647,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.300528,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
    workflow_test.go:138: []
--- PASS: TestGetWorkflowsForWorker (0.02s)
=== RUN   TestGetWorkflow
{"level":"info","ts":1605025139.3024194,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3109877,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3178945,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3286865,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestGetWorkflow (0.03s)
=== RUN   TestDeleteWorkflow
{"level":"info","ts":1605025139.3313582,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.337011,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.34357,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3524847,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestDeleteWorkflow (0.02s)
=== RUN   TestUpdateWorkflow
{"level":"info","ts":1605025139.3562808,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3628936,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3702433,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3785267,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestUpdateWorkflow (0.03s)
=== RUN   TestUpdateWorkflowState
{"level":"info","ts":1605025139.3823028,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3870876,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.3945692,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.405049,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
--- PASS: TestUpdateWorkflowState (0.03s)
=== RUN   TestGetWorkflowContexts
{"level":"info","ts":1605025139.4081707,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.4128814,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.4190562,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1605025139.4281046,"caller":"db/common_test.go:38","msg":"host=localhost port=5432 user=tinkerbell password=tinkerbell dbname=tinkerbell sslmode=disable","service":"github.com/tinkerbell/tink"}
    workflow_test.go:231: workflow_id:"da013837-a30c-237a-adfc-2d9ad69d5011" total_number_of_actions:1
--- PASS: TestGetWorkflowContexts (0.02s)
PASS
ok      github.com/tinkerbell/tink/db   0.426s
```


## How are existing users impacted? What migration steps/scripts do we need?

- Existing users should not be impacted, but CI pipeline will need to be updated to spawn postgres instance.


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade