### PR TITLE
fix getting template by name not returning the associated id

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -36,7 +36,7 @@ type hardware interface {
 
 type template interface {
 	CreateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error
-	GetTemplate(ctx context.Context, fields map[string]string) (string, string, error)
+	GetTemplate(ctx context.Context, fields map[string]string) (string, string, string, error)
 	DeleteTemplate(ctx context.Context, name string) error
 	ListTemplates(in string, fn func(id, n string, in, del *timestamp.Timestamp) error) error
 	UpdateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error

--- a/db/mock/mock.go
+++ b/db/mock/mock.go
@@ -24,5 +24,5 @@ type DB struct {
 	InsertIntoWorkflowEventTableFunc func(ctx context.Context, wfEvent *pb.WorkflowActionStatus, time time.Time) error
 	// template
 	TemplateDB      map[string]interface{}
-	GetTemplateFunc func(ctx context.Context, fields map[string]string) (string, string, error)
+	GetTemplateFunc func(ctx context.Context, fields map[string]string) (string, string, string, error)
 }

--- a/db/mock/template.go
+++ b/db/mock/template.go
@@ -32,7 +32,7 @@ func (d DB) CreateTemplate(ctx context.Context, name string, data string, id uui
 }
 
 // GetTemplate returns a workflow template
-func (d DB) GetTemplate(ctx context.Context, fields map[string]string) (string, string, error) {
+func (d DB) GetTemplate(ctx context.Context, fields map[string]string) (string, string, string, error) {
 	return d.GetTemplateFunc(ctx, fields)
 }
 

--- a/db/template.go
+++ b/db/template.go
@@ -46,31 +46,32 @@ func (d TinkDB) CreateTemplate(ctx context.Context, name string, data string, id
 }
 
 // GetTemplate returns a workflow template
-func (d TinkDB) GetTemplate(ctx context.Context, fields map[string]string) (string, string, error) {
+func (d TinkDB) GetTemplate(ctx context.Context, fields map[string]string) (string, string, string, error) {
 	getCondition, err := buildGetCondition(fields)
 	if err != nil {
-		return "", "", errors.Wrap(err, "failed to build get condition")
+		return "", "", "", errors.Wrap(err, "failed to build get condition")
 	}
 
 	query := `
-	SELECT name, data
+	SELECT id, name, data
 	FROM template
 	WHERE
 		` + getCondition + `
 		deleted_at IS NULL
 	`
 	row := d.instance.QueryRowContext(ctx, query)
+	id := []byte{}
 	name := []byte{}
 	data := []byte{}
-	err = row.Scan(&name, &data)
+	err = row.Scan(&id, &name, &data)
 	if err == nil {
-		return string(name), string(data), nil
+		return string(id), string(name), string(data), nil
 	}
 	if err != sql.ErrNoRows {
 		err = errors.Wrap(err, "SELECT")
 		logger.Error(err)
 	}
-	return "", "", err
+	return "", "", "", err
 }
 
 // DeleteTemplate deletes a workflow template

--- a/grpc-server/template.go
+++ b/grpc-server/template.go
@@ -62,7 +62,7 @@ func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*tem
 		"id":   in.GetId(),
 		"name": in.GetName(),
 	}
-	n, d, err := s.db.GetTemplate(ctx, fields)
+	id, n, d, err := s.db.GetTemplate(ctx, fields)
 	logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
@@ -72,7 +72,7 @@ func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*tem
 		}
 		l.Error(err)
 	}
-	return &template.WorkflowTemplate{Id: in.GetId(), Name: n, Data: d}, err
+	return &template.WorkflowTemplate{Id: id, Name: n, Data: d}, err
 }
 
 // DeleteTemplate implements template.DeleteTemplate

--- a/grpc-server/template_test.go
+++ b/grpc-server/template_test.go
@@ -132,16 +132,16 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
 						if fields["name"] == templateName1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
-						return "", "", errors.New("failed to get template")
+						return "", "", "", errors.New("failed to get template")
 					},
 				},
 				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Name{Name: templateName1}},
@@ -155,16 +155,16 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
 						if fields["name"] == templateName1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
-						return "", "", errors.New("failed to get template")
+						return "", "", "", errors.New("failed to get template")
 					},
 				},
 				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Name{Name: templateName2}},
@@ -178,16 +178,16 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
 						if fields["name"] == templateName1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
-						return "", "", errors.New("failed to get template")
+						return "", "", "", errors.New("failed to get template")
 					},
 				},
 				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Id{Id: templateID1}},
@@ -201,16 +201,16 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
 						if fields["name"] == templateName1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
-						return "", "", errors.New("failed to get template")
+						return "", "", "", errors.New("failed to get template")
 					},
 				},
 				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Id{Id: templateID2}},
@@ -224,16 +224,16 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
 						if fields["name"] == templateName1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
-						return "", "", errors.New("failed to get template")
+						return "", "", "", errors.New("failed to get template")
 					},
 				},
 				getRequest: &pb.GetRequest{},
@@ -247,16 +247,16 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
 						if fields["name"] == templateName1 {
-							return "", template1, nil
+							return templateID1, templateName1, template1, nil
 						}
-						return "", "", errors.New("failed to get template")
+						return "", "", "", errors.New("failed to get template")
 					},
 				},
 			},

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -274,7 +274,7 @@ func createYaml(ctx context.Context, db db.Database, templateID string, devices 
 	fields := map[string]string{
 		"id": templateID,
 	}
-	_, templateData, err := db.GetTemplate(ctx, fields)
+	_, _, templateData, err := db.GetTemplate(ctx, fields)
 	if err != nil {
 		return "", errors.Wrapf(err, errFailedToGetTemplate, templateID)
 	}

--- a/grpc-server/workflow_test.go
+++ b/grpc-server/workflow_test.go
@@ -41,11 +41,11 @@ func TestCreateWorkflow(t *testing.T) {
 		args args
 		want want
 	}{
-		"FailedToGetTempalte": {
+		"FailedToGetTemplate": {
 			args: args{
 				db: mock.DB{
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
-						return "", "", errors.New("failed to get template")
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
+						return "", "", "", errors.New("failed to get template")
 					},
 				},
 				wfTemplate: templateID,
@@ -58,8 +58,8 @@ func TestCreateWorkflow(t *testing.T) {
 		"FailedCreatingWorkflow": {
 			args: args{
 				db: mock.DB{
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
-						return "", templateData, nil
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
+						return "", "", templateData, nil
 					},
 					CreateWorkflowFunc: func(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error {
 						return errors.New("failed to create a workfow")
@@ -75,8 +75,8 @@ func TestCreateWorkflow(t *testing.T) {
 		"SuccessCreatingWorkflow": {
 			args: args{
 				db: mock.DB{
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, error) {
-						return "", templateData, nil
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string) (string, string, string, error) {
+						return "", "", templateData, nil
 					},
 					CreateWorkflowFunc: func(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error {
 						return nil


### PR DESCRIPTION
## Description

Fetching a template by name now also returns the associated ID.

## Why is this needed

A recent PR https://github.com/tinkerbell/tink/pull/349 added the functionality of fetching a template by name. The returned template is expected to include the ID, name, and template data. However, currently, it would only return the name and the template data. The returned ID is just an empty string.

## How Has This Been Tested?

Manually

## How are existing users impacted? What migration steps/scripts do we need?

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
