### PR TITLE
Run in Kubernetes

### DIFF
--- a/deploy/kubernetes/boots.yaml
+++ b/deploy/kubernetes/boots.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: boots
+  name: boots
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boots
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: boots
+    spec:
+      containers:
+      - args:
+        - -dhcp-addr
+        - 0.0.0.0:67
+        - -tftp-addr
+        - 0.0.0.0:69
+        - -http-addr
+        - 0.0.0.0:80
+        - -log-level
+        - DEBUG
+        env:
+        - name: API_AUTH_TOKEN
+          value: ignored
+        - name: API_CONSUMER_TOKEN
+          value: ignored
+        - name: BOOTP_BIND
+          value: 0.0.0.0:67
+        - name: DATA_MODEL_VERSION
+          value: "1"
+        - name: DNS_SERVERS
+          value: 8.8.8.8
+        - name: DOCKER_REGISTRY
+          value: $(PUBLIC_IP)
+        - name: ELASTIC_SEARCH_URL
+          value: $(PUBLIC_IP):9200
+        - name: FACILITY_CODE
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: FACILITY
+        - name: HTTP_BIND
+          value: 0.0.0.0:80
+        - name: MIRROR_HOST
+          value: $(PUBLIC_IP):8080
+        - name: PUBLIC_IP
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_HOST_IP
+        - name: REGISTRY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_REGISTRY_PASSWORD
+        - name: REGISTRY_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_REGISTRY_USERNAME
+        - name: SYSLOG_BIND
+          value: 0.0.0.0:514
+        - name: TFTP_BIND
+          value: 0.0.0.0:69
+        - name: TINKERBELL_CERT_URL
+          value: http://$(PUBLIC_IP):42114/cert
+        - name: TINKERBELL_GRPC_AUTHORITY
+          value: $(PUBLIC_IP):42113
+        image: quay.io/tinkerbell/boots:latest
+        imagePullPolicy: Always
+        name: boots
+        ports:
+        - containerPort: 80
+        - containerPort: 67
+          protocol: UDP
+        - containerPort: 69
+          protocol: UDP
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: boots
+  name: boots
+spec:
+  ports:
+  - name: "80"
+    port: 80
+    targetPort: 80
+  - name: "67"
+    port: 67
+    protocol: UDP
+    targetPort: 67
+  - name: "69"
+    port: 69
+    protocol: UDP
+    targetPort: 69
+  selector:
+    app: boots
+  type: ClusterIP

--- a/deploy/kubernetes/boots.yaml
+++ b/deploy/kubernetes/boots.yaml
@@ -74,7 +74,7 @@ spec:
           value: "http://$(PUBLIC_IP):42114/cert"
         - name: TINKERBELL_GRPC_AUTHORITY
           value: "$(PUBLIC_IP):42113"
-        image: docker.io/mrchrd/boots:latest
+        image: quay.io/tinkerbell/boots:latest
         imagePullPolicy: Always
         name: boots
         ports:

--- a/deploy/kubernetes/boots.yaml
+++ b/deploy/kubernetes/boots.yaml
@@ -74,7 +74,7 @@ spec:
           value: "http://$(PUBLIC_IP):42114/cert"
         - name: TINKERBELL_GRPC_AUTHORITY
           value: "$(PUBLIC_IP):42113"
-        image: quay.io/tinkerbell/boots:latest
+        image: docker.io/mrchrd/boots:latest
         imagePullPolicy: Always
         name: boots
         ports:

--- a/deploy/kubernetes/boots.yaml
+++ b/deploy/kubernetes/boots.yaml
@@ -28,6 +28,11 @@ spec:
         - -log-level
         - DEBUG
         env:
+        - name: PUBLIC_IP
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_HOST_IP
         - name: API_AUTH_TOKEN
           value: ignored
         - name: API_CONSUMER_TOKEN
@@ -39,9 +44,9 @@ spec:
         - name: DNS_SERVERS
           value: 8.8.8.8
         - name: DOCKER_REGISTRY
-          value: $(PUBLIC_IP)
+          value: "$(PUBLIC_IP)"
         - name: ELASTIC_SEARCH_URL
-          value: $(PUBLIC_IP):9200
+          value: "$(PUBLIC_IP):9200"
         - name: FACILITY_CODE
           valueFrom:
             secretKeyRef:
@@ -50,12 +55,7 @@ spec:
         - name: HTTP_BIND
           value: 0.0.0.0:80
         - name: MIRROR_HOST
-          value: $(PUBLIC_IP):8080
-        - name: PUBLIC_IP
-          valueFrom:
-            secretKeyRef:
-              name: tinkerbell
-              key: TINKERBELL_HOST_IP
+          value: "$(PUBLIC_IP):8080"
         - name: REGISTRY_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -71,9 +71,9 @@ spec:
         - name: TFTP_BIND
           value: 0.0.0.0:69
         - name: TINKERBELL_CERT_URL
-          value: http://$(PUBLIC_IP):42114/cert
+          value: "http://$(PUBLIC_IP):42114/cert"
         - name: TINKERBELL_GRPC_AUTHORITY
-          value: $(PUBLIC_IP):42113
+          value: "$(PUBLIC_IP):42113"
         image: quay.io/tinkerbell/boots:latest
         imagePullPolicy: Always
         name: boots

--- a/deploy/kubernetes/db.yaml
+++ b/deploy/kubernetes/db.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: db
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - env:
+        - name: POSTGRES_DB
+          value: tinkerbell
+        - name: POSTGRES_PASSWORD
+          value: tinkerbell
+        - name: POSTGRES_USER
+          value: tinkerbell
+        image: docker.io/postgres:10-alpine
+        imagePullPolicy: Always
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - tinkerbell
+          failureThreshold: 30
+          periodSeconds: 1
+          timeoutSeconds: 1
+        name: postgres
+        ports:
+        - containerPort: 5432
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - tinkerbell
+          failureThreshold: 30
+          periodSeconds: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-data
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes:
+      - name: postgres-data
+        persistentVolumeClaim:
+          claimName: postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: db
+  name: postgres
+spec:
+  ports:
+  - name: "5432"
+    port: 5432
+    targetPort: 5432
+  selector:
+    app: db
+  type: ClusterIP
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: db
+  name: postgres-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kubernetes/hegel.yaml
+++ b/deploy/kubernetes/hegel.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: hegel
+  name: hegel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hegel
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: hegel
+    spec:
+      containers:
+      - env:
+        - name: DATA_MODEL_VERSION
+          value: "1"
+        - name: GRPC_PORT
+          value: "42115"
+        - name: HEGEL_FACILITY
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: FACILITY
+        - name: HEGEL_USE_TLS
+          value: "0"
+        - name: TINKERBELL_CERT_URL
+          value: http://tinkerbell:42114/cert
+        - name: TINKERBELL_GRPC_AUTHORITY
+          value: tinkerbell:42113
+        image: quay.io/tinkerbell/hegel:latest
+        imagePullPolicy: Always
+        name: hegel
+        ports:
+        - containerPort: 42115
+        - containerPort: 50061
+          hostPort: 50061
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hegel
+  name: hegel
+spec:
+  ports:
+  - name: "42115"
+    port: 42115
+    targetPort: 42115
+  - name: "50061"
+    port: 50061
+    targetPort: 50061
+  selector:
+  selector:
+    app: hegel
+  type: ClusterIP

--- a/deploy/kubernetes/nginx.yaml
+++ b/deploy/kubernetes/nginx.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: docker.io/nginx:alpine
+        imagePullPolicy: Always
+        name: nginx
+        ports:
+        - containerPort: 80
+        tty: true
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html/
+          name: nginx-data
+      restartPolicy: Always
+      volumes:
+      - name: nginx-data
+#        persistentVolumeClaim:
+#          claimName: nginx-data
+        hostPath:
+          path: /vagrant/deploy/state/webroot
+          type: Directory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  ports:
+  - name: "80"
+    nodePort: 8080
+    port: 80
+    targetPort: 80
+  selector:
+    app: nginx
+  type: NodePort
+#---
+#apiVersion: v1
+#kind: PersistentVolumeClaim
+#metadata:
+#  labels:
+#    app: nginx
+#  name: nginx-data
+#spec:
+#  accessModes:
+#  - ReadWriteOnce
+#  resources:
+#    requests:
+#      storage: 5Gi

--- a/deploy/kubernetes/registry.yaml
+++ b/deploy/kubernetes/registry.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: registry
+  name: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+      - env:
+        - name: REGISTRY_AUTH
+          value: htpasswd
+        - name: REGISTRY_AUTH_HTPASSWD_PATH
+          value: /auth/htpasswd
+        - name: REGISTRY_AUTH_HTPASSWD_REALM
+          value: Registry Realm
+        - name: REGISTRY_HTTP_ADDR
+          value: 0.0.0.0:443
+        - name: REGISTRY_HTTP_TLS_CERTIFICATE
+          value: /certs/server.pem
+        - name: REGISTRY_HTTP_TLS_KEY
+          value: /certs/server-key.pem
+        - name: A_REGISTRY_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_REGISTRY_PASSWORD
+        - name: A_REGISTRY_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_REGISTRY_USERNAME
+        image: docker.io/registry:2.7.0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /
+            port: 443
+        name: registry
+        ports:
+        - containerPort: 443
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /
+            port: 443
+        volumeMounts:
+        - mountPath: /auth
+          name: registry-auth
+        - mountPath: /certs
+          name: certs
+        - mountPath: /var/lib/registry
+          name: registry-data
+      initContainers:
+      - command: 
+        - htpasswd
+        - -Bbc
+        - "$(REGISTRY_AUTH_HTPASSWD_PATH)"
+        - "$(REGISTRY_AUTH_USERNAME)"
+        - "$(REGISTRY_AUTH_PASSWORD)"
+        env:
+        - name: REGISTRY_AUTH_HTPASSWD_PATH
+          value: /auth/htpasswd
+        - name: REGISTRY_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_REGISTRY_PASSWORD
+        - name: REGISTRY_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_REGISTRY_USERNAME
+        image: docker.io/registry:2.7.0
+        imagePullPolicy: Always
+        name: htpasswd
+        volumeMounts:
+        - mountPath: /auth
+          name: registry-auth
+      restartPolicy: Always
+      volumes:
+      - name: certs
+        secret:
+          secretName: certs
+      - name: registry-auth
+        persistentVolumeClaim:
+          claimName: registry-auth
+      - name: registry-data
+        persistentVolumeClaim:
+          claimName: registry-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: registry
+  name: registry
+spec:
+  ports:
+  - name: "443"
+    nodePort: 443
+    port: 443
+    targetPort: 443
+  selector:
+    app: registry
+  type: NodePort
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: registry
+  name: registry-auth
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Ki
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: registry
+  name: registry-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+

--- a/deploy/kubernetes/tink-cli.yaml
+++ b/deploy/kubernetes/tink-cli.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tink-cli
+  name: tink-cli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tink-cli
+  template:
+    metadata:
+      labels:
+        app: tink-cli
+    spec:
+      containers:
+      - env:
+        - name: TINKERBELL_CERT_URL
+          value: http://tinkerbell:42114/cert
+        - name: TINKERBELL_GRPC_AUTHORITY
+          value: tinkerbell:42113
+        image: quay.io/tinkerbell/tink-cli:latest
+        imagePullPolicy: Always
+        name: tink-cli
+      restartPolicy: Always

--- a/deploy/kubernetes/tink-server.yaml
+++ b/deploy/kubernetes/tink-server.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tink-server
+  name: tinkerbell
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tink-server
+  template:
+    metadata:
+      labels:
+        app: tink-server
+    spec:
+      containers:
+      - env:
+        - name: FACILITY
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: FACILITY
+        - name: PGDATABASE
+          value: tinkerbell
+        - name: PGHOST
+          value: postgres
+        - name: PGPASSWORD
+          value: tinkerbell
+        - name: PGPORT
+          value: "5432"
+        - name: PGSSLMODE
+          value: disable
+        - name: PGUSER
+          value: tinkerbell
+        - name: TINKERBELL_GRPC_AUTHORITY
+          value: :42113
+        - name: TINKERBELL_HTTP_AUTHORITY
+          value: :42114
+        - name: TINK_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_TINK_PASSWORD
+        - name: TINK_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_TINK_USERNAME
+        image: quay.io/tinkerbell/tink:latest
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /cert
+            port: 42114
+        name: tinkerbell
+        ports:
+        - containerPort: 42113
+        - containerPort: 42114
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /cert
+            port: 42114
+        name: tinkerbell
+        volumeMounts:
+        - mountPath: /certs/onprem
+          name: certs
+      initContainers:
+      - env:
+        - name: ONLY_MIGRATION
+          value: "true"
+        - name: FACILITY
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: FACILITY
+        - name: PGDATABASE
+          value: tinkerbell
+        - name: PGHOST
+          value: postgres
+        - name: PGPASSWORD
+          value: tinkerbell
+        - name: PGPORT
+          value: "5432"
+        - name: PGSSLMODE
+          value: disable
+        - name: PGUSER
+          value: tinkerbell
+        - name: TINKERBELL_GRPC_AUTHORITY
+          value: :42113
+        - name: TINKERBELL_HTTP_AUTHORITY
+          value: :42114
+        - name: TINK_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_TINK_PASSWORD
+        - name: TINK_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: tinkerbell
+              key: TINKERBELL_TINK_USERNAME
+        image: quay.io/tinkerbell/tink:latest
+        imagePullPolicy: Always
+        name: tinkerbell-migration
+        volumeMounts:
+        - mountPath: /certs/onprem
+          name: certs
+      volumes:
+      - name: certs
+        secret:
+          secretName: certs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tink-server
+  name: tinkerbell
+spec:
+  ports:
+  - name: "42113"
+    nodePort: 42113
+    port: 42113
+    targetPort: 42113
+  - name: "42114"
+    nodePort: 42114
+    port: 42114
+    targetPort: 42114
+  selector:
+    app: tink-server
+  type: NodePort

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -12,7 +12,11 @@ Vagrant.configure('2') do |config|
     provisioner.vm.box = 'generic/ubuntu1804'
     provisioner.vm.hostname = 'provisioner'
     provisioner.vm.synced_folder './../../', '/vagrant'
-    provisioner.vm.provision :shell, path: './scripts/tinkerbell.sh'
+    provisioner.vm.provision :shell,
+                             path: './scripts/tinkerbell.sh',
+                             env: {
+                               'USE_KUBERNETES' => ENV['USE_KUBERNETES']
+                             }
 
     provisioner.vm.network :private_network,
                         virtualbox__intnet: "tink_network",

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -106,6 +106,7 @@ configure_vagrant_user() (
 
 main() (
 	export DEBIAN_FRONTEND=noninteractive
+	export USE_KUBERNETES=${USE_KUBERNETES:-false}
 
 	ensure_os_packages_exists curl jq
 	ensure_docker_exists
@@ -119,7 +120,7 @@ main() (
 	. ./envrc
 
 	# Use Kubernetes, or not
-	if "${USE_KUBERNETES:-false}"; then
+	if "${USE_KUBERNETES}"; then
 		ensure_k3s_exists
 	fi
 

--- a/deploy/vagrant/scripts/tinkerbell.sh
+++ b/deploy/vagrant/scripts/tinkerbell.sh
@@ -77,7 +77,7 @@ ensure_k3s_exists() (
 	# from https://rancher.com/docs/k3s/latest/en/installation/install-options/
 	curl -fsSL "https://get.k3s.io" |
 		INSTALL_K3S_EXEC="--disable traefik --docker --kube-apiserver-arg service-node-port-range=0-65535" \
-		sudo -E sh -s -
+			sudo -E sh -s -
 )
 
 make_certs_writable() (

--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -78,8 +78,8 @@ export TINKERBELL_TINK_PASSWORD="$tink_password"
 export TINKERBELL_REGISTRY_USERNAME=admin
 export TINKERBELL_REGISTRY_PASSWORD="$registry_password"
 
-# Use Kubernetes instead of Docker Compose
-#export USE_KUBERNETES=true
+# Set to true to use Kubernetes instead of Docker Compose
+export USE_KUBERNETES=${USE_KUBERNETES:-false}
 
 # Legacy options, to be deleted:
 export FACILITY=onprem

--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -78,6 +78,9 @@ export TINKERBELL_TINK_PASSWORD="$tink_password"
 export TINKERBELL_REGISTRY_USERNAME=admin
 export TINKERBELL_REGISTRY_PASSWORD="$registry_password"
 
+# Use Kubernetes instead of Docker Compose
+#export USE_KUBERNETES=true
+
 # Legacy options, to be deleted:
 export FACILITY=onprem
 EOF


### PR DESCRIPTION
## Description

This adds an option to deploy Tinkerbell using Kubernetes (k3s) instead of Docker Compose.

## Why is this needed

This allows Tinkerbell to run in Kubernetes. This will enable further development like Helm Charts, Operators, etc.

## How Has This Been Tested?

Manually tested the Hello World workflow.

## How are existing users impacted? What migration steps/scripts do we need?

There's no impact. Users can use Kubernetes by setting up environment variable `USE_KUBERNETES=true` in `envrc`, or before launching `vagrant up` or `generate-envrc.sh`. Leaving the variable undefined or setting it to `false` will use Docker Compose as expected.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
