### PR TITLE
Tink-cli unit tests

### DIFF
--- a/cmd/tink-cli/cmd/docs_test.go
+++ b/cmd/tink-cli/cmd/docs_test.go
@@ -16,6 +16,7 @@ const (
 )
 
 func Test_docsCmd(t *testing.T) {
+	subCommand := "docs"
 	type args struct {
 		name string
 	}
@@ -31,7 +32,7 @@ func Test_docsCmd(t *testing.T) {
 			want: &cobra.Command{},
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
-				root.SetArgs([]string{"docs"})
+				root.SetArgs([]string{subCommand})
 				if err := root.Execute(); err == nil {
 					t.Error("expected an error")
 				}
@@ -44,7 +45,7 @@ func Test_docsCmd(t *testing.T) {
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
 				out := &bytes.Buffer{}
-				root.SetArgs([]string{"docs", "--help"})
+				root.SetArgs([]string{subCommand, "--help"})
 				root.SetOutput(out)
 				if err := root.Execute(); err != nil {
 					t.Error(err)
@@ -66,7 +67,7 @@ func Test_docsCmd(t *testing.T) {
 				defer os.RemoveAll(dir)
 
 				root := c.Root()
-				root.SetArgs([]string{"docs", "markdown", "--path", dir})
+				root.SetArgs([]string{subCommand, "markdown", "--path", dir})
 
 				if err := root.Execute(); err != nil {
 					t.Error(err)
@@ -96,7 +97,7 @@ func Test_docsCmd(t *testing.T) {
 				defer os.RemoveAll(dir)
 
 				root := c.Root()
-				root.SetArgs([]string{"docs", "man", "--path", dir})
+				root.SetArgs([]string{subCommand, "man", "--path", dir})
 
 				if err := root.Execute(); err != nil {
 					t.Error(err)
@@ -120,7 +121,7 @@ func Test_docsCmd(t *testing.T) {
 			want: &cobra.Command{},
 			cmdFunc: func(t *testing.T, c *cobra.Command) {
 				root := c.Root()
-				root.SetArgs([]string{"docs", "invalid"})
+				root.SetArgs([]string{subCommand, "invalid"})
 				if err := root.Execute(); err == nil {
 					t.Error("expected error")
 				}

--- a/cmd/tink-cli/cmd/hardware_test.go
+++ b/cmd/tink-cli/cmd/hardware_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func Test_hardwareCmd(t *testing.T) {
+	subCommand := "hardware"
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *cobra.Command
+		cmdFunc func(*testing.T, *cobra.Command)
+	}{
+		{
+			name: "NoArgs",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				root.SetArgs([]string{subCommand})
+				if err := root.Execute(); err != nil {
+					t.Logf("%+v", root.Args)
+					t.Error("expected an error")
+				}
+			},
+		},
+		{
+			name: "ID",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "id", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "get hardware by id") {
+					t.Error("expected output should include get hardware by id")
+				}
+			},
+		},
+		{
+			name: "List",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "list", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "list all known hardware") {
+					t.Error("expected output should include list all known hardware")
+				}
+			},
+		},
+		{
+			name: "IP",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "ip", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "get hardware by any associated ip") {
+					t.Error("expected output should include get hardware by any associated ip")
+				}
+			},
+		},
+		{
+			name: "MAC",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "mac", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "get hardware by any associated mac") {
+					t.Error("expected output should include get hardware by any associated mac")
+				}
+			},
+		},
+		{
+			name: "Delete",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "delete", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "delete hardware by id") {
+					t.Error("expected output should include delete hardware by id")
+				}
+			},
+		},
+		{
+			name: "Watch",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "watch", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "register to watch an id for any changes") {
+					t.Error("expected output should include register to watch an id for any changes")
+				}
+			},
+		},
+		{
+			name: "Push",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "push", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "push new hardware to tink") {
+					t.Error("expected output should include push new hardware to tink")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := &cobra.Command{
+				Use:     testCommand,
+				Run:     func(_ *cobra.Command, _ []string) {},
+				Version: "test",
+			}
+			rootCmd.AddCommand(hardwareCmd)
+			tt.cmdFunc(t, rootCmd)
+		})
+	}
+}

--- a/cmd/tink-cli/cmd/template_test.go
+++ b/cmd/tink-cli/cmd/template_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func Test_templateCmd(t *testing.T) {
+	subCommand := "template"
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *cobra.Command
+		cmdFunc func(*testing.T, *cobra.Command)
+	}{
+		{
+			name: "NoArgs",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				root.SetArgs([]string{subCommand})
+				if err := root.Execute(); err != nil {
+					t.Logf("%+v", root.Args)
+					t.Error("expected an error")
+				}
+			},
+		},
+		{
+			name: "List",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "list", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "list all saved templates") {
+					t.Error("expected output should include list all saved templates")
+				}
+			},
+		},
+		{
+			name: "Create",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "create", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "create a workflow template") {
+					t.Error("expected output should include create a workflow template")
+				}
+			},
+		},
+		{
+			name: "Delete",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "delete", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "delete a template") {
+					t.Error("expected output should include delete a template")
+				}
+			},
+		},
+		{
+			name: "Get",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "get", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "get a template") {
+					t.Error("expected output should include get a template")
+				}
+			},
+		},
+		{
+			name: "Update",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "update", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "update a template") {
+					t.Error("expected output should include update a template")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := &cobra.Command{
+				Use:     testCommand,
+				Run:     func(_ *cobra.Command, _ []string) {},
+				Version: "test",
+			}
+			rootCmd.AddCommand(templateCmd)
+			tt.cmdFunc(t, rootCmd)
+		})
+	}
+}

--- a/cmd/tink-cli/cmd/workflow_test.go
+++ b/cmd/tink-cli/cmd/workflow_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func Test_workflowCmd(t *testing.T) {
+	subCommand := "workflow"
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *cobra.Command
+		cmdFunc func(*testing.T, *cobra.Command)
+	}{
+		{
+			name: "NoArgs",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				root.SetArgs([]string{subCommand})
+				if err := root.Execute(); err != nil {
+					t.Logf("%+v", root.Args)
+					t.Error("expected an error")
+				}
+			},
+		},
+		{
+			name: "List",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "list", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "list all workflows") {
+					t.Error("expected output should include list all workflows")
+				}
+			},
+		},
+		{
+			name: "Create",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "create", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "create a workflow") {
+					t.Error("expected output should include create a workflow")
+				}
+			},
+		},
+		{
+			name: "Data",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "data", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "get workflow data") {
+					t.Error("expected output should include get workflow data")
+				}
+			},
+		},
+		{
+			name: "Delete",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "delete", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "delete a workflow") {
+					t.Error("expected output should include delete a workflow")
+				}
+			},
+		},
+		{
+			name: "Events",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "events", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "show all events for a workflow") {
+					t.Error("expected output should include show all events for a workflow")
+				}
+			},
+		},
+		{
+			name: "Get",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "get", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "get a workflow") {
+					t.Error("expected output should include get a workflow")
+				}
+			},
+		},
+		{
+			name: "State",
+			args: args{name: testCommand},
+			want: &cobra.Command{},
+			cmdFunc: func(t *testing.T, c *cobra.Command) {
+				root := c.Root()
+				out := &bytes.Buffer{}
+				root.SetArgs([]string{subCommand, "state", "-h"})
+				root.SetOutput(out)
+				if err := root.Execute(); err != nil {
+					t.Error(err)
+				}
+				if !strings.Contains(out.String(), "get the current workflow state") {
+					t.Error("expected output should include get the current workflow state")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootCmd := &cobra.Command{
+				Use:     testCommand,
+				Run:     func(_ *cobra.Command, _ []string) {},
+				Version: "test",
+			}
+			rootCmd.AddCommand(workflowCmd)
+			tt.cmdFunc(t, rootCmd)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: cvillanueva@equinix.com <cvillanueva@equinix.com>

## Description

Unit tests to validate functionality of tink-cli. These tests do not require external components to be live. They simply test to see if the sub-functions exists and use the help argument to return the description of the command.

## Why is this needed

To ensure commands persist between versions.

Fixes: #

## How Has This Been Tested?
Run `go test -v` from within cmd/tink-cli/cmd

```
agrant@provisioner:/vagrant/cmd/tink-cli/cmd$ go test -v
=== RUN   Test_docsCmd
=== RUN   Test_docsCmd/NoArgs
Error: accepts 1 arg(s), received 0
Usage:
  tink-cli docs [markdown|man] [flags]

Flags:
  -h, --help          help for docs
  -p, --path string   Path where documentation will be generated

=== RUN   Test_docsCmd/Help
=== RUN   Test_docsCmd/Markdown
=== RUN   Test_docsCmd/Man
=== RUN   Test_docsCmd/BadFormat
Error: invalid argument "invalid" for "tink-cli docs"
Usage:
  tink-cli docs [markdown|man] [flags]

Flags:
  -h, --help          help for docs
  -p, --path string   Path where documentation will be generated

--- PASS: Test_docsCmd (0.00s)
    --- PASS: Test_docsCmd/NoArgs (0.00s)
    --- PASS: Test_docsCmd/Help (0.00s)
    --- PASS: Test_docsCmd/Markdown (0.00s)
    --- PASS: Test_docsCmd/Man (0.00s)
    --- PASS: Test_docsCmd/BadFormat (0.00s)
=== RUN   Test_hardwareCmd
=== RUN   Test_hardwareCmd/NoArgs
tink hardware client

Usage:
  tink-cli hardware [command]

Examples:
tink hardware [command]

Available Commands:
  delete      delete hardware by id
  id          get hardware by id
  ip          get hardware by any associated ip
  list        list all known hardware
  mac         get hardware by any associated mac
  push        push new hardware to tink
  watch       register to watch an id for any changes

Flags:
  -h, --help   help for hardware

Use "tink-cli hardware [command] --help" for more information about a command.
=== RUN   Test_hardwareCmd/ID
=== RUN   Test_hardwareCmd/List
=== RUN   Test_hardwareCmd/IP
=== RUN   Test_hardwareCmd/MAC
=== RUN   Test_hardwareCmd/Delete
=== RUN   Test_hardwareCmd/Watch
=== RUN   Test_hardwareCmd/Push
--- PASS: Test_hardwareCmd (0.00s)
    --- PASS: Test_hardwareCmd/NoArgs (0.00s)
    --- PASS: Test_hardwareCmd/ID (0.00s)
    --- PASS: Test_hardwareCmd/List (0.00s)
    --- PASS: Test_hardwareCmd/IP (0.00s)
    --- PASS: Test_hardwareCmd/MAC (0.00s)
    --- PASS: Test_hardwareCmd/Delete (0.00s)
    --- PASS: Test_hardwareCmd/Watch (0.00s)
    --- PASS: Test_hardwareCmd/Push (0.00s)
=== RUN   Test_templateCmd
=== RUN   Test_templateCmd/NoArgs
tink template client

Usage:
  tink-cli template [command]

Examples:
tink template [command]

Available Commands:
  create      create a workflow template 
  delete      delete a template
  get         get a template
  list        list all saved templates
  update      update a template

Flags:
  -h, --help   help for template

Use "tink-cli template [command] --help" for more information about a command.
=== RUN   Test_templateCmd/List
=== RUN   Test_templateCmd/Create
=== RUN   Test_templateCmd/Delete
=== RUN   Test_templateCmd/Get
=== RUN   Test_templateCmd/Update
--- PASS: Test_templateCmd (0.00s)
    --- PASS: Test_templateCmd/NoArgs (0.00s)
    --- PASS: Test_templateCmd/List (0.00s)
    --- PASS: Test_templateCmd/Create (0.00s)
    --- PASS: Test_templateCmd/Delete (0.00s)
    --- PASS: Test_templateCmd/Get (0.00s)
    --- PASS: Test_templateCmd/Update (0.00s)
=== RUN   Test_workflowCmd
=== RUN   Test_workflowCmd/NoArgs
tink workflow client

Usage:
  tink-cli workflow [command]

Examples:
tink workflow [command]

Available Commands:
  create      create a workflow
  data        get workflow data
  delete      delete a workflow
  events      show all events for a workflow
  get         get a workflow
  list        list all workflows
  state       get the current workflow state

Flags:
  -h, --help   help for workflow

Use "tink-cli workflow [command] --help" for more information about a command.
=== RUN   Test_workflowCmd/List
=== RUN   Test_workflowCmd/Create
=== RUN   Test_workflowCmd/Data
=== RUN   Test_workflowCmd/Delete
=== RUN   Test_workflowCmd/Events
=== RUN   Test_workflowCmd/Get
=== RUN   Test_workflowCmd/State
--- PASS: Test_workflowCmd (0.00s)
    --- PASS: Test_workflowCmd/NoArgs (0.00s)
    --- PASS: Test_workflowCmd/List (0.00s)
    --- PASS: Test_workflowCmd/Create (0.00s)
    --- PASS: Test_workflowCmd/Data (0.00s)
    --- PASS: Test_workflowCmd/Delete (0.00s)
    --- PASS: Test_workflowCmd/Events (0.00s)
    --- PASS: Test_workflowCmd/Get (0.00s)
    --- PASS: Test_workflowCmd/State (0.00s)
PASS
ok      github.com/tinkerbell/tink/cmd/tink-cli/cmd     0.013s
```


## How are existing users impacted? What migration steps/scripts do we need?

No user impact

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] added unit or e2e tests
- [X] provided instructions on how to upgrade
