### PR TITLE
Fix #318 : Starts the db transaction after validating the data

### DIFF
--- a/db/template.go
+++ b/db/template.go
@@ -14,14 +14,14 @@ import (
 
 // CreateTemplate creates a new workflow template
 func (d TinkDB) CreateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error {
+	_, err := wflow.Parse([]byte(data))
+	if err != nil {
+		return err
+	}
+
 	tx, err := d.instance.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return errors.Wrap(err, "BEGIN transaction")
-	}
-
-	_, err = wflow.Parse([]byte(data))
-	if err != nil {
-		return err
 	}
 
 	_, err = tx.Exec(`


### PR DESCRIPTION
## Description
Moves the code for data validation before creating the db transaction.

## Why is this needed
Fixes: #318 

## How Has This Been Tested?
Ran `make test` with Linux host.
