### PR TITLE
upgrade cachix/install-nix-action to v12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       run: go test -coverprofile=coverage.txt ./...
     - name: upload codecov
       run: bash <(curl -s https://codecov.io/bash)
-    - uses: cachix/install-nix-action@v10
+    - uses: cachix/install-nix-action@v12
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: ./ci-checks.sh


### PR DESCRIPTION
Signed-off-by: Kelly Deng <kelly@packet.com>

## Description

<!--- Please describe what this PR is going to change -->
Bumps `cachix/install-nix-action` from v10 to v12 (latest version)

## Why is this needed

<!--- Link to issue you have raised -->
Github actions deprecated the `add-path` command and install-nix-action v10 indirectly used that command, which fails the action. Upgrading to v12 fixes that issue.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All checks now pass

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
