### PR TITLE
FIX #363: Added fix for template soft deletes

### DIFF
--- a/db/migration/202012031335-remove-unique-name-template.go
+++ b/db/migration/202012031335-remove-unique-name-template.go
@@ -1,0 +1,12 @@
+package migration
+
+import migrate "github.com/rubenv/sql-migrate"
+
+func Get202012031335() *migrate.Migration {
+	return &migrate.Migration{
+		Id: "202012031335-remove-unique-name-template",
+		Up: []string{`
+		ALTER TABLE template DROP CONSTRAINT template_name_key;
+`},
+	}
+}

--- a/db/migration/migration.go
+++ b/db/migration/migration.go
@@ -7,6 +7,7 @@ func GetMigrations() *migrate.MemoryMigrationSource {
 		Migrations: []*migrate.Migration{
 			Get202009171251(),
 			Get202010221010(),
+			Get202012031335(),
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: cvillanueva@equinix.com <cvillanueva@equinix.com>

## Description

This fix removes the unique attribute from the name column inside of the template table. This attribute was prevent new templates from being added - if they shared the same name. The requirement we wish to fulfill is:

1. When a user deletes a template, they should be able to create a new template with the same name. 

The problem is that we do not *hard* delete records. Instead, we add a datestamp inside of the deleted_at column and then filter any records where deleted_at is not null (getTemplate).

We still need to be able to prevent users from creating new records with the same name, if the records are still active. To meet this requirement, I added the getTemplate() function to the createTemplate() function and passed the filter of name. If a record is returned, then return an error that the record exists; otherwise, proceed with creating the record.

## Why is this needed

https://github.com/tinkerbell/tink/issues/363

Fixes: #363

## How Has This Been Tested?
- Ran the updated sql query inside of postgres. Validated that the uniqueness field was removed
- Ran db test (db unit tests are part of a different PR), and validated the requirements


## How are existing users impacted? What migration steps/scripts do we need?
- Users **must** run db migration


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
