### PR TITLE
ENG-11253: create partial unique index on template

### DIFF
--- a/db/migration/202012091055-add-partial-unique-constraint-on-template.go
+++ b/db/migration/202012091055-add-partial-unique-constraint-on-template.go
@@ -1,0 +1,12 @@
+package migration
+
+import migrate "github.com/rubenv/sql-migrate"
+
+func Get202012091055() *migrate.Migration {
+	return &migrate.Migration{
+		Id: "202012091055-add-partial-unique-constraint-on-template",
+		Up: []string{`
+                CREATE UNIQUE INDEX uidx_template_name ON template (name) WHERE deleted_at IS NULL;
+                `},
+	}
+}

--- a/db/migration/migration.go
+++ b/db/migration/migration.go
@@ -9,6 +9,7 @@ func GetMigrations() *migrate.MemoryMigrationSource {
 			Get202010071530(),
 			Get202010221010(),
 			Get202012041103(),
+			Get202012091055(),
 		},
 	}
 }

--- a/db/template.go
+++ b/db/template.go
@@ -19,13 +19,6 @@ func (d TinkDB) CreateTemplate(ctx context.Context, name string, data string, id
 		return err
 	}
 
-	fields := map[string]string{
-		"name": name,
-	}
-	_, _, _, err = d.GetTemplate(ctx, fields, false)
-	if err != sql.ErrNoRows {
-		return errors.New("Template with name '" + name + "' already exist")
-	}
 	tx, err := d.instance.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return errors.Wrap(err, "BEGIN transaction")


### PR DESCRIPTION
## Description
- Create partial unique index on template.name so that the unique constraint on name is enforced for not deleted templates.
- Remove unnecessary query check when insert into template table to avoid potential concurrent issue.

## Why is this needed
https://packet.atlassian.net/browse/ENG-11253
https://packet.atlassian.net/browse/ENG-10638

## How Has This Been Tested?
manually

## How are existing users impacted? What migration steps/scripts do we need?

New database migration "202012091055-add-partial-unique-constraint-on-template" need to be applied.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
