### PR TITLE
Fix migration id for template name key

### DIFF
--- a/db/migration/202012041103-remove-unique-constraints.go
+++ b/db/migration/202012041103-remove-unique-constraints.go
@@ -4,7 +4,7 @@ import migrate "github.com/rubenv/sql-migrate"
 
 func Get202012041103() *migrate.Migration {
 	return &migrate.Migration{
-		Id: "202010221010-remove-unique-index",
+		Id: "202012041103-template-with-same-name-are-acceptable",
 		Up: []string{`
                 ALTER TABLE template DROP CONSTRAINT template_name_key;
                 `},


### PR DESCRIPTION
Introduced by https://github.com/tinkerbell/tink/pull/371 the migration
has a wrong ID.
