### PR TITLE
Fix #377: Removing name flag from the tink template create/update command

### DIFF
--- a/cmd/tink-cli/cmd/template/create.go
+++ b/cmd/tink-cli/cmd/template/create.go
@@ -8,35 +8,29 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	tt "text/template"
 
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/template"
-	"gopkg.in/yaml.v2"
+	"github.com/tinkerbell/tink/workflow"
 )
 
 var (
-	fPath        = "path"
-	filePath     string
-	templateName string
+	file     = "file"
+	filePath string
 )
-
-type TemplateName struct {
-	Name string `yaml:"name"`
-}
 
 // createCmd represents the create subcommand for template command
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create a workflow template ",
 	Example: `tink template create [flags]
-cat /tmp/example.tmpl | tink template create `,
+cat /tmp/example.tmpl | tink template create -n example`,
 	PreRunE: func(c *cobra.Command, args []string) error {
 		if !isInputFromPipe() {
-			path, _ := c.Flags().GetString(fPath)
+			path, _ := c.Flags().GetString(file)
 			if path == "" {
-				return fmt.Errorf("either pipe the template or provide the required '--path' flag")
+				return errors.New("either pipe the template or provide the required '--file' flag")
 			}
 		}
 		return nil
@@ -55,10 +49,11 @@ cat /tmp/example.tmpl | tink template create `,
 
 		data := readAll(reader)
 		if data != nil {
-			if err := tryParseTemplate(string(data)); err != nil {
+			wf, err := workflow.Parse(data)
+			if err != nil {
 				log.Fatal(err)
 			}
-			createTemplate(data)
+			createTemplate(wf.Name, data)
 		}
 	},
 }
@@ -73,28 +68,11 @@ func readAll(reader io.Reader) []byte {
 
 func addFlags() {
 	flags := createCmd.PersistentFlags()
-	flags.StringVarP(&filePath, "path", "p", "", "path to the template file")
+	flags.StringVarP(&filePath, "file", "", "", "path to the template file")
 }
 
-func tryParseTemplate(data string) error {
-	tmpl := *tt.New("")
-	if _, err := tmpl.Parse(data); err != nil {
-		return err
-	}
-	var templ TemplateName
-	err := yaml.Unmarshal([]byte(data), &templ)
-	if err != nil {
-		return err
-	}
-	if templ.Name != "" {
-		templateName = templ.Name
-		return nil
-	}
-	return errors.New("Template does not have `name` field which is mandatory")
-}
-
-func createTemplate(data []byte) {
-	req := template.WorkflowTemplate{Name: templateName, Data: string(data)}
+func createTemplate(name string, data []byte) {
+	req := template.WorkflowTemplate{Name: name, Data: string(data)}
 	res, err := client.TemplateClient.CreateTemplate(context.Background(), &req)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/tink-cli/cmd/template/create.go
+++ b/cmd/tink-cli/cmd/template/create.go
@@ -15,10 +15,7 @@ import (
 	"github.com/tinkerbell/tink/workflow"
 )
 
-var (
-	file     = "file"
-	filePath string
-)
+var filePath string
 
 // createCmd represents the create subcommand for template command
 var createCmd = &cobra.Command{
@@ -34,8 +31,7 @@ $ tink template create --file /tmp/example.tmpl
 `,
 	PreRunE: func(c *cobra.Command, args []string) error {
 		if !isInputFromPipe() {
-			path, _ := c.Flags().GetString(file)
-			if path == "" {
+			if filePath == "" {
 				return errors.New("either pipe the template or provide the required '--file' flag")
 			}
 		}

--- a/cmd/tink-cli/cmd/template/create.go
+++ b/cmd/tink-cli/cmd/template/create.go
@@ -24,8 +24,14 @@ var (
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "create a workflow template ",
-	Example: `tink template create [flags]
-cat /tmp/example.tmpl | tink template create -n example`,
+	Long: `The create command allows you create workflow templates:
+
+# Pipe the file to create a template:
+$ cat /tmp/example.tmpl | tink template create
+
+# Create template using the --file flag:
+$ tink template create --file /tmp/example.tmpl
+`,
 	PreRunE: func(c *cobra.Command, args []string) error {
 		if !isInputFromPipe() {
 			path, _ := c.Flags().GetString(file)

--- a/cmd/tink-cli/cmd/template/update.go
+++ b/cmd/tink-cli/cmd/template/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/template"
+	"github.com/tinkerbell/tink/workflow"
 )
 
 // updateCmd represents the get subcommand for template command
@@ -19,7 +20,7 @@ var updateCmd = &cobra.Command{
 	Short:   "update a template",
 	Example: "tink template update [id] [flags]",
 	PreRunE: func(c *cobra.Command, args []string) error {
-		path, _ := c.Flags().GetString(fPath)
+		path, _ := c.Flags().GetString(file)
 		if path == "" {
 			return fmt.Errorf("%v requires at least one flag", c.UseLine())
 		}
@@ -48,10 +49,11 @@ func updateTemplate(id string) {
 	if filePath != "" {
 		data := readTemplateData()
 		if data != "" {
-			if err := tryParseTemplate(data); err != nil {
+			wf, err := workflow.Parse([]byte(data))
+			if err != nil {
 				log.Fatal(err)
 			}
-			req.Name = templateName
+			req.Name = wf.Name
 			req.Data = data
 		}
 	} else {
@@ -81,8 +83,7 @@ func readTemplateData() string {
 
 func init() {
 	flags := updateCmd.PersistentFlags()
-	flags.StringVarP(&filePath, "path", "p", "", "path to the template file")
-	flags.StringVarP(&templateName, "name", "n", "", "unique name for the template (alphanumeric)")
+	flags.StringVarP(&filePath, "file", "", "", "path to the template file")
 
 	SubCommands = append(SubCommands, updateCmd)
 }

--- a/cmd/tink-cli/cmd/template/update.go
+++ b/cmd/tink-cli/cmd/template/update.go
@@ -18,15 +18,14 @@ import (
 var updateCmd = &cobra.Command{
 	Use:   "update [id] [flags]",
 	Short: "update a workflow template",
-	Long: `The update command allows you change the definition of an existing workflow template :
+	Long: `The update command allows you change the definition of an existing workflow template:
 
 # Update an existing template:
 $ tink template update 614168df-45a5-11eb-b13d-0242ac120003 --file /tmp/example.tmpl
 `,
 	PreRunE: func(c *cobra.Command, args []string) error {
-		path, _ := c.Flags().GetString(file)
-		if path == "" {
-			return fmt.Errorf("%v requires at least one flag", c.UseLine())
+		if filePath == "" {
+			return fmt.Errorf("%v requires the '--file' flag", c.UseLine())
 		}
 		return nil
 	},

--- a/cmd/tink-cli/cmd/template/update.go
+++ b/cmd/tink-cli/cmd/template/update.go
@@ -19,9 +19,8 @@ var updateCmd = &cobra.Command{
 	Short:   "update a template",
 	Example: "tink template update [id] [flags]",
 	PreRunE: func(c *cobra.Command, args []string) error {
-		name, _ := c.Flags().GetString(fName)
 		path, _ := c.Flags().GetString(fPath)
-		if name == "" && path == "" {
+		if path == "" {
 			return fmt.Errorf("%v requires at least one flag", c.UseLine())
 		}
 		return nil
@@ -46,19 +45,17 @@ var updateCmd = &cobra.Command{
 
 func updateTemplate(id string) {
 	req := template.WorkflowTemplate{Id: id}
-	if filePath == "" && templateName != "" {
-		req.Name = templateName
-	} else if filePath != "" && templateName == "" {
+	if filePath != "" {
 		data := readTemplateData()
 		if data != "" {
 			if err := tryParseTemplate(data); err != nil {
 				log.Fatal(err)
 			}
+			req.Name = templateName
 			req.Data = data
 		}
 	} else {
-		req.Name = templateName
-		req.Data = readTemplateData()
+		log.Fatal("Nothing is provided in the file path")
 	}
 
 	_, err := client.TemplateClient.UpdateTemplate(context.Background(), &req)

--- a/cmd/tink-cli/cmd/template/update.go
+++ b/cmd/tink-cli/cmd/template/update.go
@@ -16,9 +16,13 @@ import (
 
 // updateCmd represents the get subcommand for template command
 var updateCmd = &cobra.Command{
-	Use:     "update [id] [flags]",
-	Short:   "update a template",
-	Example: "tink template update [id] [flags]",
+	Use:   "update [id] [flags]",
+	Short: "update a workflow template",
+	Long: `The update command allows you change the definition of an existing workflow template :
+
+# Update an existing template:
+$ tink template update 614168df-45a5-11eb-b13d-0242ac120003 --file /tmp/example.tmpl
+`,
 	PreRunE: func(c *cobra.Command, args []string) error {
 		path, _ := c.Flags().GetString(file)
 		if path == "" {

--- a/cmd/tink-cli/cmd/template_test.go
+++ b/cmd/tink-cli/cmd/template_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -44,8 +45,9 @@ func Test_templateCmd(t *testing.T) {
 				if err := root.Execute(); err != nil {
 					t.Error(err)
 				}
-				if !strings.Contains(out.String(), "list all saved templates") {
-					t.Error("expected output should include list all saved templates")
+				want := "list all saved templates"
+				if !strings.Contains(out.String(), want) {
+					t.Error(fmt.Errorf("unexpected output, looking for %q as a substring in %q", want, out.String()))
 				}
 			},
 		},
@@ -61,8 +63,9 @@ func Test_templateCmd(t *testing.T) {
 				if err := root.Execute(); err != nil {
 					t.Error(err)
 				}
-				if !strings.Contains(out.String(), "create a workflow template") {
-					t.Error("expected output should include create a workflow template")
+				want := "Create template using the --file flag"
+				if !strings.Contains(out.String(), want) {
+					t.Error(fmt.Errorf("unexpected output, looking for %q as a substring in %q", want, out.String()))
 				}
 			},
 		},
@@ -78,8 +81,9 @@ func Test_templateCmd(t *testing.T) {
 				if err := root.Execute(); err != nil {
 					t.Error(err)
 				}
-				if !strings.Contains(out.String(), "delete a template") {
-					t.Error("expected output should include delete a template")
+				want := "delete a template"
+				if !strings.Contains(out.String(), want) {
+					t.Error(fmt.Errorf("unexpected output, looking for %q as a substring in %q", want, out.String()))
 				}
 			},
 		},
@@ -95,8 +99,9 @@ func Test_templateCmd(t *testing.T) {
 				if err := root.Execute(); err != nil {
 					t.Error(err)
 				}
-				if !strings.Contains(out.String(), "get a template") {
-					t.Error("expected output should include get a template")
+				want := "get a template"
+				if !strings.Contains(out.String(), want) {
+					t.Error(fmt.Errorf("unexpected output, looking for %q as a substring in %q", want, out.String()))
 				}
 			},
 		},
@@ -112,8 +117,9 @@ func Test_templateCmd(t *testing.T) {
 				if err := root.Execute(); err != nil {
 					t.Error(err)
 				}
-				if !strings.Contains(out.String(), "update a template") {
-					t.Error("expected output should include update a template")
+				want := "Update an existing template"
+				if !strings.Contains(out.String(), want) {
+					t.Error(fmt.Errorf("unexpected output, looking for %q as a substring in %q", want, out.String()))
 				}
 			},
 		},


### PR DESCRIPTION
## Description

This PR will remove the `name` flag from the `tink template create/update` command in tink-cli.

## Why is this needed

Fixes: #377 

## How Has This Been Tested?

This has been tested manually over the vagrant setup.

## How to migrate?

**Current Behaviour**:
At present, the `tink template create -n <name>` allows users to provide a name to a workflow template. A user can also update this name using the `tink template update -n <new-name>` command.

The workflow template also has the `name` field. So, a workflow is getting itss name from two different and places and this can be confusing to users.
```
version: "0.1"
name: hello_world_workflow
global_timeout: 6
tasks:
  - name: "hello world"
    worker: "{{.device_1}}"
    actions:
      - name: "hello_world"
        image: hello-world
        timeout: 60
```

**New Behaviour**:
With this PR, `tink template create` and `tink template update` CLI will _not_ accept a name for the template to be created or updated. Instead, the template name will be picked from the `name` field in the template definition. 

The existing users need to run the `tink template update <id> --file <template-file>` command. This will update the name of each template as per the value of `name` field in the template definition.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [x] provided instructions on how to upgrade
