### PR TITLE
Add reflection to grpc service

### DIFF
--- a/grpc-server/grpc_server.go
+++ b/grpc-server/grpc_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tinkerbell/tink/protos/workflow"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
 )
 
 var (
@@ -71,6 +72,7 @@ func SetupGRPC(ctx context.Context, log log.Logger, facility string, db *db.Tink
 	workflow.RegisterWorkflowServiceServer(s, server)
 	hardware.RegisterHardwareServiceServer(s, server)
 	events.RegisterEventsServiceServer(s, server)
+	reflection.Register(s)
 
 	grpc_prometheus.Register(s)
 


### PR DESCRIPTION
I discovered this useful introspection technique trying to use grpcurl

https://github.com/fullstorydev/grpcurl

I know one of the use cases of the HTTP API is because they are easy to
use and more familiar.

I think we just need to write and share a bit more about how to use the
gRPC server. The gRPC community is pretty big and their tools can help
with that.

More about reflection https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md

## In practice

With this PR merged I am able to inspect the grpc server using grpcurl:

```terminal
$ grpcurl -cacert ./../state/certs/ca.pem -key ../state/certs/server-key.pem -cert ../state/certs/server.pem localhost:42113 list

github.com.tinkerbell.tink.protos.events.EventsService
github.com.tinkerbell.tink.protos.hardware.HardwareService
github.com.tinkerbell.tink.protos.template.TemplateService
github.com.tinkerbell.tink.protos.workflow.WorkflowService
grpc.reflection.v1alpha.ServerReflection
```

And I can list hardware for example:

```terminal 
$ ~/Desktop/grpcurl_1.7.0_osx_x86_64/grpcurl -cacert ./deploy/state/certs/ca.pem -key ./deploy/state/certs/server-
key.pem -cert ./deploy/state/certs/server.pem localhost:42113 github.com.tinkerbell.tink.protos.hardware.HardwareService
.All
{
  "network": {
    "interfaces": [
      {
        "dhcp": {
          "mac": "08:00:27:00:00:01",
          "arch": "x86_64",
          "ip": {
            "address": "192.168.1.5",
            "netmask": "255.255.255.248",
            "gateway": "192.168.1.1"
          }
        },
        "netboot": {
          "allowPxe": true,
          "allowWorkflow": true
        }
      }
    ]
  },
  "id": "ce2e62ed-826f-4485-a39f-a82bb74338e2",
  "metadata": "{\"facility\":{\"facility_code\":\"onprem\"},\"instance\":{},\"state\":\"\"}"
}
```

Still have to figure out how to push values, grpcurl support a `-d` field as curl but i didn't have it working yet

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>
