### PR TITLE
db: Remove hard coded role in 202010071530.

### DIFF
--- a/db/migration/202010071530-init-events-table-and-triggers.go
+++ b/db/migration/202010071530-init-events-table-and-triggers.go
@@ -6,8 +6,6 @@ func Get202010071530() *migrate.Migration {
 	return &migrate.Migration{
 		Id: "202010071530-init-events-table-and-triggers",
 		Up: []string{`
-SET ROLE tinkerbell;
-
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 DO $$ BEGIN


### PR DESCRIPTION
## Description

The hardcoded role and db names were removed in e746c25. This PR exists
from before then and I missed this when re-reviewing the PR before
merging.