### PR TITLE
Fixed: duplicate key value violates unique constraint while creating multiple workflows

### DIFF
--- a/db/migration/2020121691335-update-events-primary-key.go
+++ b/db/migration/2020121691335-update-events-primary-key.go
@@ -1,0 +1,24 @@
+package migration
+
+import migrate "github.com/rubenv/sql-migrate"
+
+// Get2020121691335 updates the primary key on events table.
+//
+// Fixes: https://github.com/tinkerbell/tink/issues/379
+//
+// We can have multiple events generated at a given time, therefore the value of
+// 'created_at' field will be same for each event. This violates the unique constraint
+// on "events_pkey", when these events are add to the events table.
+//
+// The migration changes the primary key on events table from 'created_at' to `id`,
+// which will always be unique for each event generated at any point in time.
+func Get2020121691335() *migrate.Migration {
+	return &migrate.Migration{
+		Id: "2020121691335-update-events-primary-key",
+		Up: []string{`
+			ALTER TABLE events DROP CONSTRAINT events_pkey;
+			ALTER TABLE events ADD PRIMARY KEY (id);
+			CREATE INDEX IF NOT EXISTS idx_events_created_at ON events (created_at);
+		`},
+	}
+}

--- a/db/migration/migration.go
+++ b/db/migration/migration.go
@@ -10,6 +10,7 @@ func GetMigrations() *migrate.MemoryMigrationSource {
 			Get202010221010(),
 			Get202012041103(),
 			Get202012091055(),
+			Get2020121691335(),
 		},
 	}
 }


### PR DESCRIPTION
## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #379 

## How Has This Been Tested?

1. `git clone https://github.com/kinvolk/terraform-provider-tinkerbell && cd terraform-provider-tinkerbell`
2. build new images with changes in place and update docker-compose file
3. `docker-compose -f test/docker-compose.yml up -d`
4. `TF_ACC=1 TINKERBELL_GRPC_AUTHORITY=127.0.0.1:42113 TINKERBELL_CERT_URL=http://127.0.0.1:42114/cert go test -v -run=^TestAccWorkflow_.*$ -count 100 ./tinkerbell/`