### PR TITLE
Replace CI build badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,14 +15,14 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.14.6'
-    - name: goimports
-      run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
-    - name: go vet
-      run: go vet ./...
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.31
+    - name: goimports
+      run: go get golang.org/x/tools/cmd/goimports && goimports -d . | (! grep .)
+    - name: go vet
+      run: go vet ./...
     - name: go test
       run: go test -coverprofile=coverage.txt ./...
     - name: upload codecov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tinkerbell
 
-[![Build Status](https://cloud.drone.io/api/badges/tinkerbell/tink/status.svg)](https://cloud.drone.io/tinkerbell/tink)
+[![Build Status](https://github.com/tinkerbell/tink/workflows/For%20each%20commit%20and%20PR/badge.svg)](https://github.com/tinkerbell/tink/workflows/For%20each%20commit%20and%20PR/badge.svg)
 [![codecov](https://codecov.io/gh/tinkerbell/tink/branch/master/graph/badge.svg)](https://codecov.io/gh/tinkerbell/tink)
 ![](https://img.shields.io/badge/Stability-Experimental-red.svg)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4512/badge)](https://bestpractices.coreinfrastructure.org/projects/4512)


### PR DESCRIPTION
Change build status badge in README from Drone to GitHub Actions

## Why is this needed

We don't use Drone any more.