### PR TITLE
Events are cleaned up if the resource is deleted

### DIFF
--- a/db/hardware.go
+++ b/db/hardware.go
@@ -27,6 +27,15 @@ func (d TinkDB) DeleteFromDB(ctx context.Context, id string) error {
 		return errors.Wrap(err, "DELETE")
 	}
 
+	_, err = tx.Exec(`
+	DELETE FROM events
+	WHERE
+		resource_id = $1;
+	`, id)
+	if err != nil {
+		return errors.Wrap(err, "DELETE EVENTS")
+	}
+
 	err = tx.Commit()
 	if err != nil {
 		return errors.Wrap(err, "COMMIT")

--- a/db/template.go
+++ b/db/template.go
@@ -99,7 +99,16 @@ func (d TinkDB) DeleteTemplate(ctx context.Context, id string) error {
 		id = $1;
 	`, id)
 	if err != nil {
-		return errors.Wrap(err, "UPDATE")
+		return errors.Wrap(err, "DELETE")
+	}
+
+	_, err = tx.Exec(`
+	DELETE FROM events
+	WHERE
+		resource_id = $1;
+	`, id)
+	if err != nil {
+		return errors.Wrap(err, "DELETE EVENTS")
 	}
 
 	err = tx.Commit()

--- a/db/workflow.go
+++ b/db/workflow.go
@@ -369,7 +369,7 @@ func (d TinkDB) DeleteWorkflow(ctx context.Context, id string, state int32) erro
 		workflow_id = $1;
 	`, id)
 	if err != nil {
-		return errors.Wrap(err, "Delete Workflow Error")
+		return errors.Wrap(err, "DELETE")
 	}
 
 	_, err = tx.Exec(`
@@ -378,7 +378,7 @@ func (d TinkDB) DeleteWorkflow(ctx context.Context, id string, state int32) erro
 		workflow_id = $1;
 	`, id)
 	if err != nil {
-		return errors.Wrap(err, "Delete Workflow Error")
+		return errors.Wrap(err, "DELETE")
 	}
 
 	_, err = tx.Exec(`
@@ -389,7 +389,16 @@ func (d TinkDB) DeleteWorkflow(ctx context.Context, id string, state int32) erro
 		id = $1;
 	`, id)
 	if err != nil {
-		return errors.Wrap(err, "UPDATE")
+		return errors.Wrap(err, "DELETE")
+	}
+
+	_, err = tx.Exec(`
+	DELETE FROM events
+	WHERE
+		resource_id = $1;
+	`, id)
+	if err != nil {
+		return errors.Wrap(err, "DELETE EVENTS")
 	}
 
 	err = tx.Commit()


### PR DESCRIPTION
## Description

Going forward if a resource (template, hardware, workflow, ...) is deleted, all the events for that particular resource will also be cleaned up (irrespective of configured TTL).

## Why is this needed

Fixes: #396 

## How Has This Been Tested?

- Manually over vagrant setup
- Unit Tests

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
