### PR TITLE
Must parse rendered template for hardware address validation

### DIFF
--- a/grpc-server/workflow_test.go
+++ b/grpc-server/workflow_test.go
@@ -24,7 +24,7 @@ tasks:
     actions:
     - name: "hello_world"
       image: hello-world
-	  timeout: 60`
+      timeout: 60`
 )
 
 func TestCreateWorkflow(t *testing.T) {

--- a/workflow/template_validator.go
+++ b/workflow/template_validator.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"io/ioutil"
 
@@ -19,6 +20,7 @@ const (
 	errActionDuplicateName    = "two actions in a task cannot have same name: %s"
 	errActionInvalidImage     = "invalid action image: %s"
 	errTemplateParsing        = "failed to parse template with ID %s"
+	errInvalidHardwareAddress = "failed to render template, invalid hardware address: %s"
 )
 
 // Parse parses the template yaml content into a Workflow
@@ -78,6 +80,13 @@ func RenderTemplate(templateID, templateData string, devices []byte) (string, er
 	if err != nil {
 		err = errors.Wrapf(err, errTemplateParsing, templateID)
 		return "", err
+	}
+
+	wf := MustParse(buf.Bytes())
+	for _, task := range wf.Tasks {
+		if task.WorkerAddr == "" {
+			return "", fmt.Errorf(errInvalidHardwareAddress, string(devices))
+		}
 	}
 	return buf.String(), nil
 }

--- a/workflow/template_validator.go
+++ b/workflow/template_validator.go
@@ -1,6 +1,9 @@
 package workflow
 
 import (
+	"bytes"
+	"encoding/json"
+	"html/template"
 	"io/ioutil"
 
 	"github.com/docker/distribution/reference"
@@ -15,6 +18,7 @@ const (
 	errTaskDuplicateName      = "two tasks in a template cannot have same name: %s"
 	errActionDuplicateName    = "two actions in a task cannot have same name: %s"
 	errActionInvalidImage     = "invalid action image: %s"
+	errTemplateParsing        = "failed to parse template with ID %s"
 )
 
 // Parse parses the template yaml content into a Workflow
@@ -51,6 +55,31 @@ func MustParseFromFile(path string) *Workflow {
 		panic(err)
 	}
 	return MustParse(content)
+}
+
+// RenderTemplate renders the workflow template wrt given hardware details
+func RenderTemplate(templateID, templateData string, devices []byte) (string, error) {
+	var hardware map[string]interface{}
+	err := json.Unmarshal(devices, &hardware)
+	if err != nil {
+		err = errors.Wrapf(err, errTemplateParsing, templateID)
+		return "", err
+	}
+
+	t := template.New("workflow-template")
+	_, err = t.Parse(string(templateData))
+	if err != nil {
+		err = errors.Wrapf(err, errTemplateParsing, templateID)
+		return "", err
+	}
+
+	buf := new(bytes.Buffer)
+	err = t.Execute(buf, hardware)
+	if err != nil {
+		err = errors.Wrapf(err, errTemplateParsing, templateID)
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 // validate validates a workflow template against certain requirements


### PR DESCRIPTION
## Description

The template rendering logic does not validate if the rendered template has the correct worker address or not. The `workflow create` request only fails while inserting the workflow details into the database. For example, if we have the following template:

```
version: "0.1"
name: hello_world_workflow
global_timeout: 600
tasks:
  - name: "hello world"
    worker: "{{.device_1}}"
    actions:
    - name: "hello_world"
      image: hello-world
      timeout: 60
```

Now, if we create a workflow with incorrect hardware details an error is returned from database:

```
$ tink workflow create -t e80169ae-4b35-11eb-bef7-0242ac120004 -r '{"invalid_device": "08:00:27:00:00:01"}'
// 2020/12/31 07:01:37 rpc error: code = Unknown desc = failed to create workflow: unable to insert into action list: invalid worker address:
```

## Why is this needed

The validation of the worker/hardware address must happen before making any database call. 

```
$ tink workflow create -t cb826ef8-4b61-11eb-ab9f-0242ac120004 -r '{"invalid_device": "08:00:27:00:00:01"}'
2020/12/31 12:15:37 rpc error: code = Unknown desc = failed to render template, invalid hardware address: {"invalid_device": "08:00:27:00:00:01"}

$ tink workflow create -t cb826ef8-4b61-11eb-ab9f-0242ac120004 -r '{"device_1": "08:00:27:00:00:01"}'
Created Workflow:  ecabf4ce-4b61-11eb-ab9f-0242ac120004
```

## How Has This Been Tested?

- Unit tests
- Manually over vagrant setup

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
