### PR TITLE
while setting up provisioner, check if osie file path is valid

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -260,6 +260,12 @@ setup_osie() (
 			curl -fsSL 'https://tinkerbell-oss.s3.amazonaws.com/osie-uploads/latest.tar.gz' -o ./osie.tar.gz
 			tar -zxf osie.tar.gz
 		else
+			if [ ! -f "$TB_OSIE_TAR" ]; then
+				echo "$ERR osie tar not found in the given location $TB_OSIE_TAR"
+				exit 1
+			else
+				echo "$INFO extracting osie tar"
+			fi
 			tar -zxf "$TB_OSIE_TAR"
 		fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -263,9 +263,8 @@ setup_osie() (
 			if [ ! -f "$TB_OSIE_TAR" ]; then
 				echo "$ERR osie tar not found in the given location $TB_OSIE_TAR"
 				exit 1
-			else
-				echo "$INFO extracting osie tar"
 			fi
+			echo "$INFO extracting osie tar"
 			tar -zxf "$TB_OSIE_TAR"
 		fi
 


### PR DESCRIPTION
## Description
While creating provisioner, if `TB_OSIE_TAR` is set then osie file is extracted from the file whose location/absolute path is the value of this variable. 

## Why is this needed

if `TB_OSIE_TAR` is set and the file is not present at the given path(value of TB_OSIE_TAR) workflow fails stating the Linux image is not found. Which is valid as osie directory under `deploy/state` would be empty. 


- check has been added to verify if the file is present in the given path or not. 

## How Has This Been Tested?
By creating the provisioner.
Provisioner is not created if a tar file is present at the location defined in `TB_OSIE_TAR`. 

**on success** 
![Screenshot from 2021-01-04 18-50-51](https://user-images.githubusercontent.com/13061957/103539342-df798280-4ebd-11eb-81c5-e559fe1a152d.png)

**On failure** 
![Screenshot from 2021-01-04 18-48-44](https://user-images.githubusercontent.com/13061957/103539136-86115380-4ebd-11eb-9e97-b1abe35ab986.png)




