### PR TITLE
RenderTemplate using the text/template package, not the html one

### DIFF
--- a/workflow/template_validator.go
+++ b/workflow/template_validator.go
@@ -68,7 +68,7 @@ func RenderTemplate(templateID, templateData string, devices []byte) (string, er
 		return "", err
 	}
 
-	t := template.New("workflow-template")
+	t := template.New("workflow-template").Option("missingkey=error")
 	_, err = t.Parse(string(templateData))
 	if err != nil {
 		err = errors.Wrapf(err, errTemplateParsing, templateID)

--- a/workflow/template_validator.go
+++ b/workflow/template_validator.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io/ioutil"
+	"text/template"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"

--- a/workflow/template_validator_test.go
+++ b/workflow/template_validator_test.go
@@ -237,6 +237,7 @@ func TestRenderTemplate(t *testing.T) {
 		hwAddress        []byte
 		templateID       string
 		templateData     string
+		skip             string
 		expectedError    func(t *testing.T, err error)
 		expectedTemplate string
 	}{
@@ -261,6 +262,7 @@ tasks:
 		{
 			name:         "invalid-hardware-address",
 			templateData: validTemplate,
+			skip:         "Not sure if this is an expected error or not but this test is not well written",
 			hwAddress:    []byte("{\"invalid_device\":\"08:00:27:00:00:01\"}"),
 			expectedError: func(t *testing.T, err error) {
 				if err == nil {
@@ -304,9 +306,13 @@ tasks:
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.skip != "" {
+				t.Skip(test.skip)
+			}
 			temp, err := RenderTemplate(test.templateID, test.templateData, test.hwAddress)
-			if err != nil {
+			if test.expectedError != nil {
 				test.expectedError(t, err)
+				return
 			}
 			if diff := cmp.Diff(test.expectedTemplate, temp); diff != "" {
 				t.Error(diff)

--- a/workflow/template_validator_test.go
+++ b/workflow/template_validator_test.go
@@ -237,7 +237,6 @@ func TestRenderTemplate(t *testing.T) {
 		hwAddress        []byte
 		templateID       string
 		templateData     string
-		skip             string
 		expectedError    func(t *testing.T, err error)
 		expectedTemplate string
 	}{
@@ -262,14 +261,13 @@ tasks:
 		{
 			name:         "invalid-hardware-address",
 			templateData: validTemplate,
-			skip:         "Not sure if this is an expected error or not but this test is not well written",
 			hwAddress:    []byte("{\"invalid_device\":\"08:00:27:00:00:01\"}"),
 			expectedError: func(t *testing.T, err error) {
 				if err == nil {
 					t.Error("expected error, got nil")
 				}
-				if !strings.Contains(err.Error(), "invalid hardware address: {\"invalid_device\":\"08:00:27:00:00:01\"}") {
-					t.Errorf("\nexpected err: %s\ngot: %s", "invalid hardware address: {\"invalid_device\":\"08:00:27:00:00:01\"}", err)
+				if !strings.Contains(err.Error(), `executing "workflow-template" at <.device_1>: map has no entry for key "device_1"`) {
+					t.Errorf("\nexpected err: %s\ngot: %s", `executing "workflow-template" at <.device_1>: map has no entry for key "device_1"`, err)
 				}
 			},
 		},
@@ -306,9 +304,6 @@ tasks:
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.skip != "" {
-				t.Skip(test.skip)
-			}
 			temp, err := RenderTemplate(test.templateID, test.templateData, test.hwAddress)
 			if test.expectedError != nil {
 				test.expectedError(t, err)


### PR DESCRIPTION
## Description

Apparently, we imported the wrong package, we need to use text no HTML rules.

## Why is this needed

Wrong import, we do not need to escape following HTML rules.
Fixes: #415 

## How Has This Been Tested?
 Unit test


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
