### PR TITLE
Remove gRPC TLS cert

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -1,10 +1,7 @@
 package client
 
 import (
-	"crypto/x509"
-	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 
 	"github.com/pkg/errors"
@@ -14,7 +11,6 @@ import (
 	"github.com/tinkerbell/tink/protos/template"
 	"github.com/tinkerbell/tink/protos/workflow"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // gRPC clients
@@ -67,35 +63,15 @@ func NewFullClient(conn grpc.ClientConnInterface) *FullClient {
 }
 
 type ConnOptions struct {
-	CertURL       string
 	GRPCAuthority string
 }
 
 func (o *ConnOptions) SetFlags(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&o.CertURL, "tinkerbell-cert-url", "http://127.0.0.1:42114/cert", "The URL where the certificate is located")
 	flagSet.StringVar(&o.GRPCAuthority, "tinkerbell-grpc-authority", "127.0.0.1:42113", "Link to tink-server grcp api")
 }
 
 func NewClientConn(opt *ConnOptions) (*grpc.ClientConn, error) {
-	resp, err := http.Get(opt.CertURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "fetch cert")
-	}
-	defer resp.Body.Close()
-
-	certs, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "read cert")
-	}
-
-	cp := x509.NewCertPool()
-	ok := cp.AppendCertsFromPEM(certs)
-	if !ok {
-		return nil, errors.Wrap(err, "parse cert")
-	}
-
-	creds := credentials.NewClientTLSFromCert(cp, "")
-	conn, err := grpc.Dial(opt.GRPCAuthority, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.Dial(opt.GRPCAuthority)
 	if err != nil {
 		return nil, errors.Wrap(err, "connect to tinkerbell server")
 	}
@@ -104,33 +80,11 @@ func NewClientConn(opt *ConnOptions) (*grpc.ClientConn, error) {
 
 // GetConnection returns a gRPC client connection
 func GetConnection() (*grpc.ClientConn, error) {
-	certURL := os.Getenv("TINKERBELL_CERT_URL")
-	if certURL == "" {
-		return nil, errors.New("undefined TINKERBELL_CERT_URL")
-	}
-	resp, err := http.Get(certURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "fetch cert")
-	}
-	defer resp.Body.Close()
-
-	certs, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "read cert")
-	}
-
-	cp := x509.NewCertPool()
-	ok := cp.AppendCertsFromPEM(certs)
-	if !ok {
-		return nil, errors.Wrap(err, "parse cert")
-	}
-
 	grpcAuthority := os.Getenv("TINKERBELL_GRPC_AUTHORITY")
 	if grpcAuthority == "" {
 		return nil, errors.New("undefined TINKERBELL_GRPC_AUTHORITY")
 	}
-	creds := credentials.NewClientTLSFromCert(cp, "")
-	conn, err := grpc.Dial(grpcAuthority, grpc.WithTransportCredentials(creds))
+	conn, err := grpc.Dial(grpcAuthority)
 	if err != nil {
 		return nil, errors.Wrap(err, "connect to tinkerbell server")
 	}


### PR DESCRIPTION
The way we do TLS in Tinkerbell is just a complication.
It does not increase security because everybody that knows how to
download the certificate from the tink-server can connect.

It can't be used to identify the requester and it means that
is not a carrier that we can use for authorisation moving forward.

With a couple of other maintainers we would like to remove TLS
completely for now until we can figure out a better design for it.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>
