### PR TITLE
Fix permissions on downloaded artifacts:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,8 @@ jobs:
       with:
           name: ${{ matrix.binary}}
           path: cmd/${{ matrix.binary }}
+    - name: Fix Permissions
+      run: chmod +x cmd/${{ matrix.binary }}*
     - name: ${{ matrix.repository }}
       uses: docker/build-push-action@v2
       with:


### PR DESCRIPTION
## Description

The Github Action `actions/upload-artifact@v2` does not preserve file permissions on upload. https://github.com/actions/upload-artifact/tree/v2#permission-loss
This means almost certainly all docker images, before this commit, are not working.
I have validated that with the latest tags, as shown here:

![image](https://user-images.githubusercontent.com/12081036/106689206-ccc19e80-658c-11eb-8937-caba2c07885c.png)

It's difficult to test this change. I think this will work but will need it to run in Github actions to actually know.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
