### PR TITLE
Migrate tink-server to cobra and viper

### DIFF
--- a/cmd/tink-server/main.go
+++ b/cmd/tink-server/main.go
@@ -6,9 +6,14 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/packethost/pkg/log"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"github.com/tinkerbell/tink/client/listener"
 	"github.com/tinkerbell/tink/db"
 	rpcServer "github.com/tinkerbell/tink/grpc-server"
@@ -18,93 +23,248 @@ import (
 var (
 	// version is set at build time
 	version = "devel"
-
-	logger log.Logger
 )
 
-func main() {
-	log, err := log.Init("github.com/tinkerbell/tink")
-	if err != nil {
-		panic(err)
+// DaemonConfig represents all the values you can configure as part of the tink-server.
+// You can change the configuration via environment variable, or file, or command flags.
+type DaemonConfig struct {
+	Facility              string
+	PGDatabase            string
+	PGUSer                string
+	PGPassword            string
+	PGSSLMode             string
+	OnlyMigration         bool
+	GRPCAuthority         string
+	TLSCert               string
+	CertDir               string
+	HTTPAuthority         string
+	HTTPBasicAuthUsername string
+	HTTPBasicAuthPassword string
+}
+
+func (c *DaemonConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&c.Facility, "facility", "deprecated", "This is temporary. It will be removed")
+	fs.StringVar(&c.PGDatabase, "postgres-database", "tinkerbell", "The Postgres database name")
+	fs.StringVar(&c.PGUSer, "postgres-user", "tinkerbell", "The Postgres database username")
+	fs.StringVar(&c.PGPassword, "postgres-password", "tinkerbell", "The Postgres database password")
+	fs.StringVar(&c.PGSSLMode, "postgres-sslmode", "disable", "Enable or disable SSL mode in postgres")
+	fs.BoolVar(&c.OnlyMigration, "only-migration", false, "When enabled it ")
+	fs.StringVar(&c.GRPCAuthority, "grpc-authority", ":42113", "The address used to expose the gRPC server")
+	fs.StringVar(&c.TLSCert, "tls-cert", "", "")
+	fs.StringVar(&c.CertDir, "cert-dir", "", "")
+	fs.StringVar(&c.HTTPAuthority, "http-authority", ":42114", "The address used to expose the HTTP server")
+}
+
+func (c *DaemonConfig) PopulateFromLegacyEnvVar() {
+	if f := os.Getenv("FACILITY"); f != "" {
+		c.Facility = f
 	}
-	logger = log
-	defer logger.Close()
-	log.Info("starting version " + version)
-
-	ctx, closer := context.WithCancel(context.Background())
-	errCh := make(chan error, 2)
-	facility := os.Getenv("FACILITY")
-
-	// TODO(gianarb): I moved this up because we need to be sure that both
-	// connection, the one used for the resources and the one used for
-	// listening to events and notification are coming in the same way.
-	// BUT we should be using the right flags
-	connInfo := fmt.Sprintf("dbname=%s user=%s password=%s sslmode=%s",
-		os.Getenv("PGDATABASE"),
-		os.Getenv("PGUSER"),
-		os.Getenv("PGPASSWORD"),
-		os.Getenv("PGSSLMODE"),
-	)
-
-	dbCon, err := sql.Open("postgres", connInfo)
-	if err != nil {
-		logger.Error(err)
-		panic(err)
+	if pgdb := os.Getenv("PGDATABASE"); pgdb != "" {
+		c.PGDatabase = pgdb
 	}
-	tinkDB := db.Connect(dbCon, logger)
-
-	_, onlyMigration := os.LookupEnv("ONLY_MIGRATION")
-	if onlyMigration {
-		logger.Info("Applying migrations. This process will end when migrations will take place.")
-		numAppliedMigrations, err := tinkDB.Migrate()
-		if err != nil {
-			log.Fatal(err)
-			panic(err)
+	if pguser := os.Getenv("PGUSER"); pguser != "" {
+		c.PGUSer = pguser
+	}
+	if pgpass := os.Getenv("PGPASSWORD"); pgpass != "" {
+		c.PGPassword = pgpass
+	}
+	if pgssl := os.Getenv("PGSSLMODE"); pgssl != "" {
+		c.PGSSLMode = pgssl
+	}
+	if onlyMigration, isSet := os.LookupEnv("ONLY_MIGRATION"); isSet {
+		if b, err := strconv.ParseBool(onlyMigration); err != nil {
+			c.OnlyMigration = b
 		}
-		log.With("num_applied_migrations", numAppliedMigrations).Info("Migrations applied successfully")
-		os.Exit(0)
 	}
+	if tlsCert := os.Getenv("TINKERBELL_TLS_CERT"); tlsCert != "" {
+		c.TLSCert = tlsCert
+	}
+	if certDir := os.Getenv("TINKERBELL_CERTS_DIR"); certDir != "" {
+		c.CertDir = certDir
+	}
+	if grpcAuthority := os.Getenv("TINKERBELL_GRPC_AUTHORITY"); grpcAuthority != "" {
+		c.GRPCAuthority = grpcAuthority
+	}
+	if httpAuthority := os.Getenv("TINKERBELL_HTTP_AUTHORITY"); httpAuthority != "" {
+		c.HTTPAuthority = httpAuthority
+	}
+	if basicAuthUser := os.Getenv("TINK_AUTH_USERNAME"); basicAuthUser != "" {
+		c.HTTPBasicAuthUsername = basicAuthUser
+	}
+	if basicAuthPass := os.Getenv("TINK_AUTH_PASSWORD"); basicAuthPass != "" {
+		c.HTTPBasicAuthPassword = basicAuthPass
+	}
+}
 
-	err = listener.Init(connInfo)
+func main() {
+	logger, err := log.Init("github.com/tinkerbell/tink")
 	if err != nil {
-		log.Fatal(err)
 		panic(err)
 	}
+	defer logger.Close()
 
-	go tinkDB.PurgeEvents(errCh)
+	config := &DaemonConfig{}
 
-	numAvailableMigrations, err := tinkDB.CheckRequiredMigrations()
-	if err != nil {
-		log.Fatal(err)
-		panic(err)
-	}
-	if numAvailableMigrations != 0 {
-		log.Info("Your database schema is not up to date. Please apply migrations running tink-server with env var ONLY_MIGRATION set.")
+	cmd := NewRootCommand(config, logger)
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		os.Exit(1)
 	}
 
-	cert, modT := rpcServer.SetupGRPC(ctx, logger, facility, tinkDB, errCh)
-	httpServer.SetupHTTP(ctx, logger, cert, modT, errCh)
+}
 
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
-	select {
-	case err = <-errCh:
-		logger.Error(err)
-		panic(err)
-	case sig := <-sigs:
-		logger.With("signal", sig.String()).Info("signal received, stopping servers")
-	}
-	closer()
+func NewRootCommand(config *DaemonConfig, logger log.Logger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "tink-server",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			viper, err := createViper(logger)
+			if err != nil {
+				return err
+			}
+			return applyViper(viper, cmd)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// I am not sure if it is right for this to be here,
+			// but as last step I want to keep compatibility with
+			// what we have for a little bit and I thinik that's
+			// the most aggressive way we have to guarantee that
+			// the old way works as before.
+			config.PopulateFromLegacyEnvVar()
 
-	// wait for grpc server to shutdown
-	err = <-errCh
-	if err != nil {
-		log.Fatal(err)
-		panic(err)
+			logger.Info("starting version " + version)
+
+			sigs := make(chan os.Signal, 1)
+			signal.Notify(sigs, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
+			ctx, closer := context.WithCancel(cmd.Context())
+			defer closer()
+			// TODO(gianarb): I think we can do better in terms of
+			// graceful shutdown and error management but I want to
+			// figure this out in another PR
+			errCh := make(chan error, 2)
+
+			// TODO(gianarb): I moved this up because we need to be sure that both
+			// connection, the one used for the resources and the one used for
+			// listening to events and notification are coming in the same way.
+			// BUT we should be using the right flags
+			connInfo := fmt.Sprintf("dbname=%s user=%s password=%s sslmode=%s",
+				config.PGDatabase,
+				config.PGUSer,
+				config.PGPassword,
+				config.PGSSLMode,
+			)
+
+			dbCon, err := sql.Open("postgres", connInfo)
+			if err != nil {
+				return err
+			}
+			tinkDB := db.Connect(dbCon, logger)
+
+			if config.OnlyMigration {
+				logger.Info("Applying migrations. This process will end when migrations will take place.")
+				numAppliedMigrations, err := tinkDB.Migrate()
+				if err != nil {
+					return err
+				}
+				logger.With("num_applied_migrations", numAppliedMigrations).Info("Migrations applied successfully")
+				return nil
+			}
+
+			err = listener.Init(connInfo)
+			if err != nil {
+				return err
+			}
+
+			go tinkDB.PurgeEvents(errCh)
+
+			numAvailableMigrations, err := tinkDB.CheckRequiredMigrations()
+			if err != nil {
+				return err
+			}
+			if numAvailableMigrations != 0 {
+				logger.Info("Your database schema is not up to date. Please apply migrations running tink-server with env var ONLY_MIGRATION set.")
+			}
+
+			cert, modT := rpcServer.SetupGRPC(ctx, logger, &rpcServer.ConfigGRPCServer{
+				Facility:      config.Facility,
+				TLSCert:       config.TLSCert,
+				GRPCAuthority: config.GRPCAuthority,
+				DB:            tinkDB,
+			}, errCh)
+
+			httpServer.SetupHTTP(ctx, logger, &httpServer.HTTPServerConfig{
+				CertPEM:               cert,
+				ModTime:               modT,
+				GRPCAuthority:         config.GRPCAuthority,
+				HTTPAuthority:         config.HTTPAuthority,
+				HTTPBasicAuthUsername: config.HTTPBasicAuthUsername,
+				HTTPBasicAuthPassword: config.HTTPBasicAuthPassword,
+			}, errCh)
+
+			<-ctx.Done()
+			select {
+			case err = <-errCh:
+				logger.Error(err)
+			case sig := <-sigs:
+				logger.With("signal", sig.String()).Info("signal received, stopping servers")
+			}
+
+			// wait for grpc server to shutdown
+			err = <-errCh
+			if err != nil {
+				return err
+			}
+			err = <-errCh
+			if err != nil {
+				return err
+			}
+			return nil
+		},
 	}
-	err = <-errCh
-	if err != nil {
-		log.Fatal(err)
-		panic(err)
+	config.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func createViper(logger log.Logger) (*viper.Viper, error) {
+	v := viper.New()
+	v.AutomaticEnv()
+	v.SetConfigName("tink-server")
+	v.AddConfigPath("/etc/tinkerbell")
+	v.AddConfigPath(".")
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	// If a config file is found, read it in.
+	if err := v.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			logger.With("configFile", v.ConfigFileUsed()).Error(err, "could not load config file")
+			return nil, err
+		}
+		logger.Info("no config file found")
+	} else {
+		logger.With("configFile", v.ConfigFileUsed()).Info("loaded config file")
 	}
+
+	return v, nil
+}
+
+func applyViper(v *viper.Viper, cmd *cobra.Command) error {
+	errors := []error{}
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
+				errors = append(errors, err)
+				return
+			}
+		}
+	})
+
+	if len(errors) > 0 {
+		errs := []string{}
+		for _, err := range errors {
+			errs = append(errs, err.Error())
+		}
+		return fmt.Errorf(strings.Join(errs, ", "))
+	}
+
+	return nil
 }

--- a/cmd/tink-server/main.go
+++ b/cmd/tink-server/main.go
@@ -48,7 +48,7 @@ func (c *DaemonConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.PGUSer, "postgres-user", "tinkerbell", "The Postgres database username")
 	fs.StringVar(&c.PGPassword, "postgres-password", "tinkerbell", "The Postgres database password")
 	fs.StringVar(&c.PGSSLMode, "postgres-sslmode", "disable", "Enable or disable SSL mode in postgres")
-	fs.BoolVar(&c.OnlyMigration, "only-migration", false, "When enabled it ")
+	fs.BoolVar(&c.OnlyMigration, "only-migration", false, "When enabled the server applies the migration to postgres database and it exits")
 	fs.StringVar(&c.GRPCAuthority, "grpc-authority", ":42113", "The address used to expose the gRPC server")
 	fs.StringVar(&c.TLSCert, "tls-cert", "", "")
 	fs.StringVar(&c.CertDir, "cert-dir", "", "")

--- a/grpc-server/events.go
+++ b/grpc-server/events.go
@@ -17,14 +17,13 @@ func (s *server) Watch(req *events.WatchRequest, stream events.EventsService_Wat
 		return stream.Send(event)
 	})
 	if err != nil && err != io.EOF {
-		logger.Error(err)
 		return err
 	}
 
 	return listener.Listen(req, func(e *events.Event) error {
 		err := stream.Send(e)
 		if err != nil {
-			logger.With("eventTypes", req.EventTypes, "resourceTypes", req.ResourceTypes).Info("events stream closed")
+			s.logger.With("eventTypes", req.EventTypes, "resourceTypes", req.ResourceTypes).Info("events stream closed")
 			return listener.RemoveHandlers(req)
 		}
 		return nil

--- a/grpc-server/template.go
+++ b/grpc-server/template.go
@@ -15,7 +15,7 @@ import (
 
 // CreateTemplate implements template.CreateTemplate
 func (s *server) CreateTemplate(ctx context.Context, in *template.WorkflowTemplate) (*template.CreateResponse, error) {
-	logger.Info("createtemplate")
+	s.logger.Info("createtemplate")
 	labels := prometheus.Labels{"method": "CreateTemplate", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
@@ -28,24 +28,24 @@ func (s *server) CreateTemplate(ctx context.Context, in *template.WorkflowTempla
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
-	logger.Info(msg)
+	s.logger.Info(msg)
 	err := s.db.CreateTemplate(ctx, in.Name, in.Data, id)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		l := logger
+		l := s.logger
 		if pqErr := db.Error(err); pqErr != nil {
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
 		l.Error(err)
 		return &template.CreateResponse{}, err
 	}
-	logger.Info("done " + msg)
+	s.logger.Info("done " + msg)
 	return &template.CreateResponse{Id: id.String()}, err
 }
 
 // GetTemplate implements template.GetTemplate
 func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*template.WorkflowTemplate, error) {
-	logger.Info("gettemplate")
+	s.logger.Info("gettemplate")
 	labels := prometheus.Labels{"method": "GetTemplate", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
@@ -57,16 +57,16 @@ func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*tem
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
-	logger.Info(msg)
+	s.logger.Info(msg)
 	fields := map[string]string{
 		"id":   in.GetId(),
 		"name": in.GetName(),
 	}
 	id, n, d, err := s.db.GetTemplate(ctx, fields, false)
-	logger.Info("done " + msg)
+	s.logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		l := logger
+		l := s.logger
 		if pqErr := db.Error(err); pqErr != nil {
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
@@ -77,7 +77,7 @@ func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*tem
 
 // DeleteTemplate implements template.DeleteTemplate
 func (s *server) DeleteTemplate(ctx context.Context, in *template.GetRequest) (*template.Empty, error) {
-	logger.Info("deletetemplate")
+	s.logger.Info("deletetemplate")
 	labels := prometheus.Labels{"method": "DeleteTemplate", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
@@ -89,12 +89,12 @@ func (s *server) DeleteTemplate(ctx context.Context, in *template.GetRequest) (*
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
-	logger.Info(msg)
+	s.logger.Info(msg)
 	err := s.db.DeleteTemplate(ctx, in.GetId())
-	logger.Info("done " + msg)
+	s.logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		l := logger
+		l := s.logger
 		if pqErr := db.Error(err); pqErr != nil {
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
@@ -105,7 +105,7 @@ func (s *server) DeleteTemplate(ctx context.Context, in *template.GetRequest) (*
 
 // ListTemplates implements template.ListTemplates
 func (s *server) ListTemplates(in *template.ListRequest, stream template.TemplateService_ListTemplatesServer) error {
-	logger.Info("listtemplates")
+	s.logger.Info("listtemplates")
 	labels := prometheus.Labels{"method": "ListTemplates", "op": "list"}
 	metrics.CacheTotals.With(labels).Inc()
 	metrics.CacheInFlight.With(labels).Inc()
@@ -141,7 +141,7 @@ func (s *server) ListTemplates(in *template.ListRequest, stream template.Templat
 
 // UpdateTemplate implements template.UpdateTemplate
 func (s *server) UpdateTemplate(ctx context.Context, in *template.WorkflowTemplate) (*template.Empty, error) {
-	logger.Info("updatetemplate")
+	s.logger.Info("updatetemplate")
 	labels := prometheus.Labels{"method": "UpdateTemplate", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
@@ -153,12 +153,12 @@ func (s *server) UpdateTemplate(ctx context.Context, in *template.WorkflowTempla
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
-	logger.Info(msg)
+	s.logger.Info(msg)
 	err := s.db.UpdateTemplate(ctx, in.Name, in.Data, uuid.MustParse(in.Id))
-	logger.Info("done " + msg)
+	s.logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		l := logger
+		l := s.logger
 		if pqErr := db.Error(err); pqErr != nil {
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}

--- a/grpc-server/template_test.go
+++ b/grpc-server/template_test.go
@@ -140,7 +140,7 @@ func TestCreateTemplate(t *testing.T) {
 		tc := testCases[name]
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			s := testServer(tc.args.db)
+			s := testServer(t, tc.args.db)
 			res, err := s.CreateTemplate(ctx, &pb.WorkflowTemplate{Name: tc.args.name, Data: tc.args.template})
 			if tc.want.expectedError {
 				assert.Error(t, err)
@@ -311,7 +311,7 @@ func TestGetTemplate(t *testing.T) {
 		tc := testCases[name]
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			s := testServer(tc.args.db)
+			s := testServer(t, tc.args.db)
 			res, err := s.GetTemplate(ctx, tc.args.getRequest)
 			if tc.err {
 				assert.Error(t, err)

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -25,7 +25,7 @@ const errFailedToGetTemplate = "failed to get template with ID %s"
 
 // CreateWorkflow implements workflow.CreateWorkflow
 func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest) (*workflow.CreateResponse, error) {
-	logger.Info("createworkflow")
+	s.logger.Info("createworkflow")
 	labels := prometheus.Labels{"method": "CreateWorkflow", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
@@ -41,7 +41,7 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
-	logger.Info(msg)
+	s.logger.Info(msg)
 	fields := map[string]string{
 		"id": in.GetTemplate(),
 	}
@@ -53,7 +53,7 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		logger.Error(err)
+		s.logger.Error(err)
 		return &workflow.CreateResponse{}, err
 	}
 
@@ -66,7 +66,7 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 	err = s.db.CreateWorkflow(ctx, wf, data, id)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		l := logger
+		l := s.logger
 		if pqErr := db.Error(err); pqErr != nil {
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
@@ -74,14 +74,14 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 		return &workflow.CreateResponse{}, err
 	}
 
-	l := logger.With("workflowID", id.String())
+	l := s.logger.With("workflowID", id.String())
 	l.Info("done " + msg)
 	return &workflow.CreateResponse{Id: id.String()}, err
 }
 
 // GetWorkflow implements workflow.GetWorkflow
 func (s *server) GetWorkflow(ctx context.Context, in *workflow.GetRequest) (*workflow.Workflow, error) {
-	logger.Info("getworkflow")
+	s.logger.Info("getworkflow")
 	labels := prometheus.Labels{"method": "GetWorkflow", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
@@ -93,11 +93,11 @@ func (s *server) GetWorkflow(ctx context.Context, in *workflow.GetRequest) (*wor
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
-	logger.Info(msg)
+	s.logger.Info(msg)
 	w, err := s.db.GetWorkflow(ctx, in.Id)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		l := logger
+		l := s.logger
 		if pqErr := db.Error(err); pqErr != nil {
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
@@ -122,21 +122,21 @@ func (s *server) GetWorkflow(ctx context.Context, in *workflow.GetRequest) (*wor
 		State:    state[w.State],
 		Data:     data,
 	}
-	l := logger.With("workflowID", w.ID)
+	l := s.logger.With("workflowID", w.ID)
 	l.Info("done " + msg)
 	return wf, err
 }
 
 // DeleteWorkflow implements workflow.DeleteWorkflow
 func (s *server) DeleteWorkflow(ctx context.Context, in *workflow.GetRequest) (*workflow.Empty, error) {
-	logger.Info("deleteworkflow")
+	s.logger.Info("deleteworkflow")
 	labels := prometheus.Labels{"method": "DeleteWorkflow", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
 	const msg = "deleting a workflow"
 	labels["op"] = "delete"
-	l := logger.With("workflowID", in.GetId())
+	l := s.logger.With("workflowID", in.GetId())
 
 	metrics.CacheTotals.With(labels).Inc()
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
@@ -146,7 +146,7 @@ func (s *server) DeleteWorkflow(ctx context.Context, in *workflow.GetRequest) (*
 	err := s.db.DeleteWorkflow(ctx, in.Id, workflow.State_value[workflow.State_STATE_RUNNING.String()])
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		l := logger
+		l := s.logger
 		if pqErr := db.Error(err); pqErr != nil {
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
@@ -158,7 +158,7 @@ func (s *server) DeleteWorkflow(ctx context.Context, in *workflow.GetRequest) (*
 
 // ListWorkflows implements workflow.ListWorkflows
 func (s *server) ListWorkflows(_ *workflow.Empty, stream workflow.WorkflowService_ListWorkflowsServer) error {
-	logger.Info("listworkflows")
+	s.logger.Info("listworkflows")
 	labels := prometheus.Labels{"method": "ListWorkflows", "op": "list"}
 	metrics.CacheTotals.With(labels).Inc()
 	metrics.CacheInFlight.With(labels).Inc()
@@ -195,7 +195,7 @@ func (s *server) ListWorkflows(_ *workflow.Empty, stream workflow.WorkflowServic
 }
 
 func (s *server) GetWorkflowContext(ctx context.Context, in *workflow.GetRequest) (*workflow.WorkflowContext, error) {
-	logger.Info("GetworkflowContext")
+	s.logger.Info("GetworkflowContext")
 	labels := prometheus.Labels{"method": "GetWorkflowContext", "op": ""}
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
@@ -207,11 +207,11 @@ func (s *server) GetWorkflowContext(ctx context.Context, in *workflow.GetRequest
 	timer := prometheus.NewTimer(metrics.CacheDuration.With(labels))
 	defer timer.ObserveDuration()
 
-	logger.Info(msg)
+	s.logger.Info(msg)
 	w, err := s.db.GetWorkflowContexts(ctx, in.Id)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
-		l := logger
+		l := s.logger
 		if pqErr := db.Error(err); pqErr != nil {
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
@@ -226,7 +226,7 @@ func (s *server) GetWorkflowContext(ctx context.Context, in *workflow.GetRequest
 		CurrentActionState:   workflow.State(w.CurrentActionState),
 		TotalNumberOfActions: w.TotalNumberOfActions,
 	}
-	l := logger.With(
+	l := s.logger.With(
 		"workflowID", wf.GetWorkflowId(),
 		"currentWorker", wf.GetCurrentWorker(),
 		"currentTask", wf.GetCurrentTask(),
@@ -241,7 +241,7 @@ func (s *server) GetWorkflowContext(ctx context.Context, in *workflow.GetRequest
 
 // ShowWorflowevents  implements workflow.ShowWorflowEvents
 func (s *server) ShowWorkflowEvents(req *workflow.GetRequest, stream workflow.WorkflowService_ShowWorkflowEventsServer) error {
-	logger.Info("List workflows Events")
+	s.logger.Info("List workflows Events")
 	labels := prometheus.Labels{"method": "ShowWorkflowEvents", "op": "list"}
 	metrics.CacheTotals.With(labels).Inc()
 	metrics.CacheInFlight.With(labels).Inc()
@@ -274,7 +274,7 @@ func (s *server) ShowWorkflowEvents(req *workflow.GetRequest, stream workflow.Wo
 		metrics.CacheErrors.With(labels).Inc()
 		return err
 	}
-	logger.Info("done listing workflows events")
+	s.logger.Info("done listing workflows events")
 	metrics.CacheHits.With(labels).Inc()
 	return nil
 }

--- a/grpc-server/workflow_test.go
+++ b/grpc-server/workflow_test.go
@@ -95,7 +95,7 @@ func TestCreateWorkflow(t *testing.T) {
 	defer cancel()
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			s := testServer(tc.args.db)
+			s := testServer(t, tc.args.db)
 			res, err := s.CreateWorkflow(ctx, &workflow.CreateRequest{
 				Hardware: tc.args.wfHardware,
 				Template: tc.args.wfTemplate,
@@ -153,7 +153,7 @@ func TestGetWorkflow(t *testing.T) {
 	defer cancel()
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			s := testServer(tc.args.db)
+			s := testServer(t, tc.args.db)
 			res, err := s.GetWorkflow(ctx, &workflow.GetRequest{
 				Id: workflowID,
 			})


### PR DESCRIPTION
This PR refactors how tink-server starts.
It uses Cobra and Viper same as tink-cli and tink-worker.

Right now it tries to keep compatibility with the old way of doing
things.

TODO:

- [x] run this version in sandbox without any change. it should work like before
- [ ] ~Unit test (project aborted, I don't know how to mock env var!)~

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>
