### PR TITLE
Fix tink-client gRPC flags for get and delete command

### DIFF
--- a/cmd/tink-cli/cmd/delete/delete.go
+++ b/cmd/tink-cli/cmd/delete/delete.go
@@ -77,10 +77,6 @@ func NewDeleteCommand(opt Options) *cobra.Command {
 			if opt.fullClient != nil {
 				return nil
 			}
-			if opt.clientConnOpt == nil {
-				opt.SetClientConnOpt(&client.ConnOptions{})
-			}
-			opt.clientConnOpt.SetFlags(cmd.PersistentFlags())
 			return nil
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -119,5 +115,9 @@ func NewDeleteCommand(opt Options) *cobra.Command {
 			return nil
 		},
 	}
+	if opt.clientConnOpt == nil {
+		opt.SetClientConnOpt(&client.ConnOptions{})
+	}
+	opt.clientConnOpt.SetFlags(cmd.PersistentFlags())
 	return cmd
 }

--- a/cmd/tink-cli/cmd/get/get.go
+++ b/cmd/tink-cli/cmd/get/get.go
@@ -69,10 +69,6 @@ func NewGetCommand(opt Options) *cobra.Command {
 			if opt.fullClient != nil {
 				return nil
 			}
-			if opt.clientConnOpt == nil {
-				opt.SetClientConnOpt(&client.ConnOptions{})
-			}
-			opt.clientConnOpt.SetFlags(cmd.PersistentFlags())
 			return nil
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -153,5 +149,9 @@ func NewGetCommand(opt Options) *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVarP(&opt.Format, "format", "", "table", "The format you expect the list to be printed out. Currently supported format are table, JSON and CSV")
 	cmd.PersistentFlags().BoolVar(&opt.NoHeaders, "no-headers", false, "Table contains an header with the columns' name. You can disable it from being printed out")
+	if opt.clientConnOpt == nil {
+		opt.SetClientConnOpt(&client.ConnOptions{})
+	}
+	opt.clientConnOpt.SetFlags(cmd.PersistentFlags())
 	return cmd
 }


### PR DESCRIPTION
## Description

Playing with the CLI with JWB we noticed that flags related to
tink-client was not properly added to the get and delete command.

This commit fixes the issue.

## Why is this needed

I have added the capability to convert gRPC connection options to flags, but they were not attached to the get and delete command in the right way
