### PR TITLE
Log to stderr to notify that CLI is looking for deprecated environment

### DIFF
--- a/cmd/tink-cli/cmd/delete/delete.go
+++ b/cmd/tink-cli/cmd/delete/delete.go
@@ -89,7 +89,7 @@ func NewDeleteCommand(opt Options) *cobra.Command {
 				var conn *grpc.ClientConn
 				conn, err = client.NewClientConn(opt.clientConnOpt)
 				if err != nil {
-					println("Flag based client configuration failed with err: %s. Trying with env var legacy method...", err)
+					fmt.Fprintf(cmd.ErrOrStderr(), "Flag based client configuration failed with err: %s. Trying with env var legacy method...", err)
 					// Fallback to legacy Setup via env var
 					conn, err = client.GetConnection()
 					if err != nil {

--- a/cmd/tink-cli/cmd/get/get.go
+++ b/cmd/tink-cli/cmd/get/get.go
@@ -81,7 +81,7 @@ func NewGetCommand(opt Options) *cobra.Command {
 				var conn *grpc.ClientConn
 				conn, err = client.NewClientConn(opt.clientConnOpt)
 				if err != nil {
-					println("Flag based client configuration failed with err: %s. Trying with env var legacy method...", err)
+					fmt.Fprintf(cmd.ErrOrStderr(), "Flag based client configuration failed with err: %s. Trying with env var legacy method...", err)
 					// Fallback to legacy Setup via env var
 					conn, err = client.GetConnection()
 					if err != nil {


### PR DESCRIPTION
## Description

Get and delete cli command got rewritten to gain consistency. One of the
additional features is better flag support.

The gRPC connection to tink-server can now be changed via flags, but the
warning who notified when the retro compatible and deprecated code get
executed was not printed to stderr.

## Why is this needed

To be able to pipe the output of the command to other scripts or commands.