### PR TITLE
Add flag to allow you to disable tink-worker action logging rollup

### DIFF
--- a/cmd/tink-worker/cmd/root.go
+++ b/cmd/tink-worker/cmd/root.go
@@ -48,6 +48,7 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 			user, _ := cmd.Flags().GetString("registry-username")
 			pwd, _ := cmd.Flags().GetString("registry-password")
 			registry, _ := cmd.Flags().GetString("docker-registry")
+			captureActionLogs, _ := cmd.Flags().GetBool("capture-action-logs")
 
 			logger.With("version", version).Info("starting")
 			if setupErr := client.Setup(); setupErr != nil {
@@ -70,7 +71,7 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 			regConn := internal.NewRegistryConnDetails(registry, user, pwd, logger)
 			worker := internal.NewWorker(rClient, regConn, logger, registry, retries, retryInterval, maxFileSize)
 
-			err = worker.ProcessWorkflowActions(ctx, workerID)
+			err = worker.ProcessWorkflowActions(ctx, workerID, captureActionLogs)
 			if err != nil {
 				return errors.Wrap(err, "worker Finished with error")
 			}
@@ -85,6 +86,8 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 	rootCmd.Flags().Int("max-retry", defaultRetryCount, "Maximum number of retries to attempt (MAX_RETRY)")
 
 	rootCmd.Flags().Int64("max-file-size", defaultMaxFileSize, "Maximum file size in bytes (MAX_FILE_SIZE)")
+
+	rootCmd.Flags().Bool("capture-action-logs", true, "Capture action container output as part of worker logs")
 
 	// rootCmd.Flags().String("log-level", "info", "Sets the worker log level (panic, fatal, error, warn, info, debug, trace)")
 

--- a/cmd/tink-worker/internal/action.go
+++ b/cmd/tink-worker/internal/action.go
@@ -21,7 +21,7 @@ const (
 	infoWaitFinished = "wait finished for failed or timeout container"
 )
 
-func (w *Worker) createContainer(ctx context.Context, cmd []string, wfID string, action *pb.WorkflowAction) (string, error) {
+func (w *Worker) createContainer(ctx context.Context, cmd []string, wfID string, action *pb.WorkflowAction, captureLogs bool) (string, error) {
 	registry := w.registry
 	config := &container.Config{
 		Image:        path.Join(registry, action.GetImage()),
@@ -30,6 +30,11 @@ func (w *Worker) createContainer(ctx context.Context, cmd []string, wfID string,
 		Cmd:          cmd,
 		Tty:          true,
 		Env:          action.GetEnvironment(),
+	}
+	if !captureLogs {
+		config.AttachStdout = true
+		config.AttachStderr = true
+		config.Tty = false
 	}
 
 	wfDir := filepath.Join(dataDir, wfID)

--- a/cmd/tink-worker/internal/worker.go
+++ b/cmd/tink-worker/internal/worker.go
@@ -149,8 +149,9 @@ func (w *Worker) execute(ctx context.Context, wfID string, action *pb.WorkflowAc
 			}
 			l.With("containerID", id, "status", status.String(), "command", action.GetOnTimeout()).Info("container created")
 			failedActionStatus := make(chan pb.State)
-			// TODD(jwb) Need to handle this capture logs as well
-			go w.captureLogs(ctx, id)
+			if captureLogs {
+				go w.captureLogs(ctx, id)
+			}
 			go waitFailedContainer(ctx, l, cli, id, failedActionStatus)
 			err = startContainer(ctx, l, cli, id)
 			if err != nil {
@@ -165,8 +166,9 @@ func (w *Worker) execute(ctx context.Context, wfID string, action *pb.WorkflowAc
 					l.Error(errors.Wrap(err, errFailedToRunCmd))
 				}
 				l.With("containerID", id, "actionStatus", status.String(), "command", action.GetOnFailure()).Info("container created")
-				// TODO(jwb) - Handle logging here too
-				go w.captureLogs(ctx, id)
+				if captureLogs {
+					go w.captureLogs(ctx, id)
+				}
 				go waitFailedContainer(ctx, l, cli, id, failedActionStatus)
 				err = startContainer(ctx, l, cli, id)
 				if err != nil {


### PR DESCRIPTION
## Description

Currently tink-worker attaches to the 'console' of each action container and logs its STDOUT/STDERR alongside tink-worker's normal output.    This change allows this behavior to be disabled through a flag.

## Why is this needed

We wish to log all action output centrally via syslog as configured in the docker 'daemon.json'.    If we enable that, and tink-worker still wants to grab the action logs the conflict will cause actions to fail to execute.
