### PR TITLE
Tink CLI Template create should use --file instead of -p

### DIFF
--- a/cmd/tink-cli/cmd/template/create.go
+++ b/cmd/tink-cli/cmd/template/create.go
@@ -57,7 +57,7 @@ $ tink template create --file /tmp/example.tmpl
 		},
 	}
 	flags := cmd.PersistentFlags()
-	flags.StringVarP(&filePath, "path", "p", "", "path to the template file")
+	flags.StringVar(&filePath, "file", "./template.yaml", "path to the template file")
 	return cmd
 }
 


### PR DESCRIPTION
A few weeks ago we decided to use --file for template creation:

https://github.com/tinkerbell/tink/pull/385

But a few days ago probably during a rebase, I broke that
behavior and left the template to create command in a broken state

https://github.com/tinkerbell/tink/commit/76793ee8ab85e1cbebc0c97c67012dcb8ad002c0#diff-f5b9b4afa42ee036d5b6836337e9d6273de8c341267f7ea75eddc561f0ad6441

As detected by Dan https://github.com/tinkerbell/tink/issues/445

This commit should fix the issue, and it will require a documentation
update as soon as we release a new version of the sandbox.

Fixed #445