### PR TITLE
Fixed #381: 'tink workflow state' command returns an error if workflow does not exist

### DIFF
--- a/db/workflow.go
+++ b/db/workflow.go
@@ -350,13 +350,13 @@ func (d TinkDB) GetWorkflow(ctx context.Context, id string) (Workflow, error) {
 	if err == nil {
 		return Workflow{ID: id, Template: tmp, Hardware: tar}, nil
 	}
-
 	if err != sql.ErrNoRows {
 		err = errors.Wrap(err, "SELECT")
 		d.logger.Error(err)
+		return Workflow{}, err
 	}
 
-	return Workflow{}, nil
+	return Workflow{}, errors.New("Workflow with id " + id + " does not exist")
 }
 
 // DeleteWorkflow deletes a workflow
@@ -549,8 +549,9 @@ func (d TinkDB) GetWorkflowContexts(ctx context.Context, wfID string) (*pb.Workf
 	if err != sql.ErrNoRows {
 		err = errors.Wrap(err, "SELECT from worflow_state")
 		d.logger.Error(err)
+		return &pb.WorkflowContext{}, err
 	}
-	return &pb.WorkflowContext{}, nil
+	return &pb.WorkflowContext{}, errors.New("Workflow with id " + wfID + " does not exist")
 }
 
 // GetWorkflowActions : gives you the action list of workflow

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -102,8 +102,8 @@ func (s *server) GetWorkflow(ctx context.Context, in *workflow.GetRequest) (*wor
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
 		l.Error(err)
+		return &workflow.Workflow{}, err
 	}
-
 	fields := map[string]string{
 		"id": w.Template,
 	}
@@ -200,7 +200,7 @@ func (s *server) GetWorkflowContext(ctx context.Context, in *workflow.GetRequest
 	metrics.CacheInFlight.With(labels).Inc()
 	defer metrics.CacheInFlight.With(labels).Dec()
 
-	const msg = "getting a workflow"
+	const msg = "getting a workflow context"
 	labels["op"] = "get"
 
 	metrics.CacheTotals.With(labels).Inc()

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -216,6 +216,7 @@ func (s *server) GetWorkflowContext(ctx context.Context, in *workflow.GetRequest
 			l = l.With("detail", pqErr.Detail, "where", pqErr.Where)
 		}
 		l.Error(err)
+		return &workflow.WorkflowContext{}, err
 	}
 	wf := &workflow.WorkflowContext{
 		WorkflowId:           w.WorkflowId,


### PR DESCRIPTION
Signed-off-by: parauliya <aman@infracloud.io>

## Description

Now `tink workflow state <wfid>`  command will return an error if the workflow with id `wfid` does not exist.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #381 

## How Has This Been Tested?
Tested with Vagrant setup.


## How are existing users impacted? What migration steps/scripts do we need?
No Impact on existing users. 

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
