### PR TITLE
docker graceful exits when image pull fails #382

### DIFF
--- a/cmd/tink-worker/internal/registry_test.go
+++ b/cmd/tink-worker/internal/registry_test.go
@@ -1,0 +1,75 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/packethost/pkg/log"
+	//"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupTestLogger(t *testing.T) log.Logger {
+	service := "github.com/tinkerbell/tink"
+	logger, err := log.Init(service)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return logger
+}
+
+type imagePullerMock struct {
+	stringReadCloser io.ReadCloser
+	imagePullErr     error
+}
+
+func (d *imagePullerMock) ImagePull(ctx context.Context, str string, op types.ImagePullOptions) (io.ReadCloser, error) {
+	return d.stringReadCloser, d.imagePullErr
+}
+
+func TestPullImageAnyFailure(t *testing.T) {
+	for _, test := range []struct {
+		testName         string
+		testString       string
+		testImagePullErr error
+		testErr          error
+	}{
+		{
+			testName:         "success",
+			testString:       "{\"status\": \"hello\",\"error\":\"\"}{\"status\":\"world\",\"error\":\"\"}",
+			testImagePullErr: nil,
+			testErr:          nil,
+		},
+		{
+			testName:         "fail",
+			testString:       "{\"error\": \"\"}",
+			testImagePullErr: errors.New("Tested, failure of the image pull"),
+			testErr:          errors.New("DOCKER PULL: Tested, failure of the image pull"),
+		},
+		{
+			testName:         "fail_partial",
+			testString:       "{\"status\": \"hello\",\"error\":\"\"}{\"status\":\"world\",\"error\":\"Tested, failure of No space left on device\"}",
+			testImagePullErr: nil,
+			testErr:          errors.New("DOCKER PULL: Tested, failure of No space left on device"),
+		},
+	} {
+		t.Run(test.testName, func(t *testing.T) {
+			ctx := context.Background()
+			rcon := NewRegistryConnDetails("test", "testUser", "testPwd", setupTestLogger(t))
+			stringReader := strings.NewReader(test.testString)
+			cli := &imagePullerMock{
+				stringReadCloser: ioutil.NopCloser(stringReader),
+				imagePullErr:     test.testImagePullErr,
+			}
+			err := rcon.pullImage(ctx, cli, test.testName)
+			if test.testErr != nil {
+				assert.Equal(t, err.Error(), test.testErr.Error())
+			}
+		})
+	}
+}

--- a/cmd/tink-worker/internal/registry_test.go
+++ b/cmd/tink-worker/internal/registry_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/packethost/pkg/log"
-	//"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,6 +68,8 @@ func TestPullImageAnyFailure(t *testing.T) {
 			err := rcon.pullImage(ctx, cli, test.testName)
 			if test.testErr != nil {
 				assert.Equal(t, err.Error(), test.testErr.Error())
+			} else {
+				assert.Equal(t, err, test.testErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Docker image pull will do a graceful exit when an error is encountered.

## Why is this needed

- currently, with the go library `io.Copy`, an error is generated if the image pull fails, primarily when space is not left on the device.
- More details: https://github.com/tinkerbell/tink/issues/382#issuecomment-789672128 

Fixes: #

- Have removed the `io.Copy` 
- Added pull of an image and Error check via a struct. 

## How Has This Been Tested?
- Tested on Vagrant setup. 
- Test with the below template. 
```
version: "0.1"
name: helloworkflow
global_timeout: 600
tasks:
  - name: "hello world 1"
    worker: "{{.device_1}}"
    actions:
      - name: "hello_world_1"
        image: hello-world
        timeout: 60
      - name: "hello_world_2"
        image: test
        timeout: 200

```

- Test logs covers both +ve and -ve scearios.
- success with `hello-world` image and failure with a very large size dummy image of around 1 GB. 
```
{"level":"info","ts":1615207865.9741204,"caller":"cmd/root.go:132","msg":"no config file found","service":"github.com/tinkerbell/tink"}
{"level":"info","ts":1615207865.9748633,"caller":"cmd/root.go:53","msg":"starting","service":"github.com/tinkerbell/tink","version":"d0780ce"}
{"level":"info","ts":1615207865.992383,"caller":"internal/worker.go:270","msg":"starting with action","service":"github.com/tinkerbell/tink","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","actionName":"hello_world_1","taskName":"hello world 1"}
{"level":"info","ts":1615207865.9968224,"caller":"internal/worker.go:293","msg":"sent action status","service":"github.com/tinkerbell/tink","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","actionName":"hello_world_1","taskName":"hello world 1","duration":"0"}
{"level":"info","ts":1615207866.195519,"caller":"internal/action.go:54","msg":"creating container","service":"github.com/tinkerbell/tink","command":[]}
{"level":"info","ts":1615207866.2004075,"caller":"internal/worker.go:108","msg":"container created","service":"github.com/tinkerbell/tink","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","actionName":"hello_world_1","actionImage":"hello-world","containerID":"42482e6c52c6d13a44b8fc2456979409c9a4051ddf78b45c72ca7d3c9802daa7","command":[]}

Hello from Docker!
This message shows that your installation appears to be working correctly.

To generate this message, Docker took the following steps:
 1. The Docker client contacted the Docker daemon.
 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
    (amd64)
 3. The Docker daemon created a new container from that image which runs the
    executable that produces the output you are currently reading.
 4. The Docker daemon streamed that output to the Docker client, which sent it
    to your terminal.

To try something more ambitious, you can run an Ubuntu container with:
 $ docker run -it ubuntu bash

Share images, automate workflows, and more with a free Docker ID:
 https://hub.docker.com/

For more examples and ideas, visit:
 https://docs.docker.com/get-started/

{"level":"info","ts":1615207866.688619,"caller":"internal/worker.go:143","msg":"container removed","service":"github.com/tinkerbell/tink","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","actionName":"hello_world_1","actionImage":"hello-world","status":"STATE_SUCCESS"}
{"level":"info","ts":1615207866.6886694,"caller":"internal/worker.go:186","msg":"action container exited","service":"github.com/tinkerbell/tink","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","actionName":"hello_world_1","actionImage":"hello-world","status":"STATE_SUCCESS"}
{"level":"info","ts":1615207866.688689,"caller":"internal/action.go:115","msg":"removing container","service":"github.com/tinkerbell/tink","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","actionName":"hello_world_1","actionImage":"hello-world","containerID":"42482e6c52c6d13a44b8fc2456979409c9a4051ddf78b45c72ca7d3c9802daa7"}
{"level":"info","ts":1615207866.6984775,"caller":"internal/worker.go:334","msg":"sent action status","service":"github.com/tinkerbell/tink","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","actionName":"hello_world_1","taskName":"hello world 1"}
{"level":"info","ts":1615207866.712187,"caller":"internal/worker.go:293","msg":"sent action status","service":"github.com/tinkerbell/tink","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","actionName":"hello_world_2","taskName":"hello world 1","duration":"0"}
{"level":"error","ts":1615207891.0433881,"caller":"internal/worker.go:319","msg":"DOCKER PULL: DOCKER PULL: failed to register layer: Error processing tar file(exit status 1): write /root/test123/570bbc7011b5f6155f4631fc33753f02f7e8288bd8f2fac20d766e437e8f1bbe/layer.tar: no space left on device","service":"github.com/tinkerbell/tink","workerID":"0eba0bf8-3772-4b4a-ab9f-6ebe93b90a94","workflowID":"b19960b8-800c-11eb-ba2c-0242ac120005","actionName":"hello_world_2","taskName":"hello world 1","error":"DOCKER PULL: DOCKER PULL: failed to register layer: Error processing tar file(exit status 1): write /root/test123/570bbc7011b5f6155f4631fc33753f02f7e8288bd8f2fac20d766e437e8f1bbe/layer.tar: no space left on device","errorVerbose":"failed to register layer: Error processing tar file(exit status 1): write /root/test123/570bbc7011b5f6155f4631fc33753f02f7e8288bd8f2fac20d766e437e8f1bbe/layer.tar: no space left on device\ngithub.com/tinkerbell/tink/cmd/tink-worker/internal.(*RegistryConnDetails).pullImage\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/internal/registry.go:86\ngithub.com/tinkerbell/tink/cmd/tink-worker/internal.(*Worker).execute\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/internal/worker.go:101\ngithub.com/tinkerbell/tink/cmd/tink-worker/internal.(*Worker).ProcessWorkflowActions\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/internal/worker.go:301\ngithub.com/tinkerbell/tink/cmd/tink-worker/cmd.NewRootCommand.func2\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/cmd/root.go:74\ngithub.com/spf13/cobra.(*Command).execute\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:842\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:950\ngithub.com/spf13/cobra.(*Command).Execute\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:887\nmain.main\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/main.go:29\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373\nDOCKER PULL\ngithub.com/tinkerbell/tink/cmd/tink-worker/internal.(*RegistryConnDetails).pullImage\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/internal/registry.go:86\ngithub.com/tinkerbell/tink/cmd/tink-worker/internal.(*Worker).execute\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/internal/worker.go:101\ngithub.com/tinkerbell/tink/cmd/tink-worker/internal.(*Worker).ProcessWorkflowActions\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/internal/worker.go:301\ngithub.com/tinkerbell/tink/cmd/tink-worker/cmd.NewRootCommand.func2\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/cmd/root.go:74\ngithub.com/spf13/cobra.(*Command).execute\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:842\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:950\ngithub.com/spf13/cobra.(*Command).Execute\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:887\nmain.main\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/main.go:29\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373\nDOCKER PULL\ngithub.com/tinkerbell/tink/cmd/tink-worker/internal.(*Worker).execute\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/internal/worker.go:102\ngithub.com/tinkerbell/tink/cmd/tink-worker/internal.(*Worker).ProcessWorkflowActions\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/internal/worker.go:301\ngithub.com/tinkerbell/tink/cmd/tink-worker/cmd.NewRootCommand.func2\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/cmd/root.go:74\ngithub.com/spf13/cobra.(*Command).execute\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:842\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:950\ngithub.com/spf13/cobra.(*Command).Execute\n\t/home/Chitrabasu/Downloads/work/gocode/pkg/mod/github.com/spf13/cobra@v1.0.1-0.20200713175500-884edc58ad08/command.go:887\nmain.main\n\t/home/Chitrabasu/Downloads/work/repo/tink/cmd/tink-worker/main.go:29\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1373"}
Error: worker Finished with error: DOCKER PULL: DOCKER PULL: failed to register layer: Error processing tar file(exit status 1): write /root/test123/570bbc7011b5f6155f4631fc33753f02f7e8288bd8f2fac20d766e437e8f1bbe/layer.tar: no space left on device
Usage:
  tink-worker [flags]

Flags:
      --capture-action-logs        Capture action container output as part of worker logs (default true)
  -r, --docker-registry string     Sets the Docker registry (DOCKER_REGISTRY)
  -h, --help                       help for tink-worker
  -i, --id string                  Sets the worker id (ID)
      --max-file-size int          Maximum file size in bytes (MAX_FILE_SIZE) (default 10485760)
      --max-retry int              Maximum number of retries to attempt (MAX_RETRY) (default 3)
  -p, --registry-password string   Sets the registry-password (REGISTRY_PASSWORD)
  -u, --registry-username string   Sets the registry username (REGISTRY_USERNAME)
      --retry-interval duration    Retry interval in seconds (RETRY_INTERVAL) (default 3ns)
      --timeout duration           Max duration to wait for worker to complete (TIMEOUT) (default 1h0m0s)
  -v, --version                    version for tink-worker
```

Please note:
This change, additionally, alters the details of logs collection when an image is pulled. This is to avoid unnecessary details in the logs. Same has been concluded to remove via #451 