### PR TITLE
Fix_475: Correct timestamps in get by Id commands for template and workflow

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	migrate "github.com/rubenv/sql-migrate"
 	"github.com/tinkerbell/tink/db/migration"
+	tb "github.com/tinkerbell/tink/protos/template"
 	pb "github.com/tinkerbell/tink/protos/workflow"
 )
 
@@ -34,7 +35,7 @@ type hardware interface {
 
 type template interface {
 	CreateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error
-	GetTemplate(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error)
+	GetTemplate(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error)
 	DeleteTemplate(ctx context.Context, name string) error
 	ListTemplates(in string, fn func(id, n string, in, del *timestamp.Timestamp) error) error
 	UpdateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error

--- a/db/mock/mock.go
+++ b/db/mock/mock.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/tinkerbell/tink/db"
+	tb "github.com/tinkerbell/tink/protos/template"
 	pb "github.com/tinkerbell/tink/protos/workflow"
 )
 
@@ -25,5 +26,5 @@ type DB struct {
 	InsertIntoWorkflowEventTableFunc func(ctx context.Context, wfEvent *pb.WorkflowActionStatus, time time.Time) error
 	// template
 	TemplateDB      map[string]interface{}
-	GetTemplateFunc func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error)
+	GetTemplateFunc func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error)
 }

--- a/db/mock/template.go
+++ b/db/mock/template.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/uuid"
+	tb "github.com/tinkerbell/tink/protos/template"
 )
 
 type Template struct {
@@ -41,7 +42,7 @@ func (d DB) CreateTemplate(ctx context.Context, name string, data string, id uui
 }
 
 // GetTemplate returns a workflow template
-func (d DB) GetTemplate(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
+func (d DB) GetTemplate(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 	return d.GetTemplateFunc(ctx, fields, deleted)
 }
 

--- a/db/template.go
+++ b/db/template.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	tb "github.com/tinkerbell/tink/protos/template"
 	wflow "github.com/tinkerbell/tink/workflow"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -48,16 +49,16 @@ func (d TinkDB) CreateTemplate(ctx context.Context, name string, data string, id
 }
 
 // GetTemplate returns template which is not deleted
-func (d TinkDB) GetTemplate(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
+func (d TinkDB) GetTemplate(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 	getCondition, err := buildGetCondition(fields)
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "failed to get template")
+		return &tb.WorkflowTemplate{}, errors.Wrap(err, "failed to get template")
 	}
 
 	var query string
 	if !deleted {
 		query = `
-	SELECT id, name, data
+	SELECT id, name, data, created_at, updated_at
 	FROM template
 	WHERE
 		` + getCondition + ` AND
@@ -65,7 +66,7 @@ func (d TinkDB) GetTemplate(ctx context.Context, fields map[string]string, delet
 	`
 	} else {
 		query = `
-	SELECT id, name, data
+	SELECT id, name, data, created_at, updated_at
 	FROM template
 	WHERE
 		` + getCondition + `
@@ -73,18 +74,30 @@ func (d TinkDB) GetTemplate(ctx context.Context, fields map[string]string, delet
 	}
 
 	row := d.instance.QueryRowContext(ctx, query)
-	id := []byte{}
-	name := []byte{}
-	data := []byte{}
-	err = row.Scan(&id, &name, &data)
+	var (
+		id        string
+		name      string
+		data      string
+		createdAt time.Time
+		updatedAt time.Time
+	)
+	err = row.Scan(&id, &name, &data, &createdAt, &updatedAt)
 	if err == nil {
-		return string(id), string(name), string(data), nil
+		crAt, _ := ptypes.TimestampProto(createdAt)
+		upAt, _ := ptypes.TimestampProto(updatedAt)
+		return &tb.WorkflowTemplate{
+			Id:        id,
+			Name:      name,
+			Data:      data,
+			CreatedAt: crAt,
+			UpdatedAt: upAt,
+		}, nil
 	}
 	if err != sql.ErrNoRows {
 		err = errors.Wrap(err, "SELECT")
 		d.logger.Error(err)
 	}
-	return "", "", "", err
+	return &tb.WorkflowTemplate{}, err
 }
 
 // DeleteTemplate deletes a workflow template by id

--- a/db/template_test.go
+++ b/db/template_test.go
@@ -45,13 +45,13 @@ func TestCreateTemplate(t *testing.T) {
 				}(),
 			},
 			Expectation: func(t *testing.T, input []*workflow.Workflow, tinkDB *db.TinkDB) {
-				wID, wName, wData, err := tinkDB.GetTemplate(ctx, map[string]string{"id": input[0].ID}, false)
+				wtmpl, err := tinkDB.GetTemplate(ctx, map[string]string{"id": input[0].ID}, false)
 				if err != nil {
 					t.Error(err)
 				}
-				w := workflow.MustParse([]byte(wData))
-				w.ID = wID
-				w.Name = wName
+				w := workflow.MustParse([]byte(wtmpl.GetData()))
+				w.ID = wtmpl.GetId()
+				w.Name = wtmpl.GetName()
 				if dif := cmp.Diff(input[0], w); dif != "" {
 					t.Errorf(dif)
 				}
@@ -96,12 +96,12 @@ func TestCreateTemplate(t *testing.T) {
 				}(),
 			},
 			Expectation: func(t *testing.T, input []*workflow.Workflow, tinkDB *db.TinkDB) {
-				_, wName, _, err := tinkDB.GetTemplate(context.Background(), map[string]string{"id": input[0].ID}, false)
+				wtmpl, err := tinkDB.GetTemplate(context.Background(), map[string]string{"id": input[0].ID}, false)
 				if err != nil {
 					t.Error(err)
 				}
-				if wName != "updated-name" {
-					t.Errorf("expected name to be \"%s\", got \"%s\"", "updated-name", wName)
+				if wtmpl.GetName() != "updated-name" {
+					t.Errorf("expected name to be \"%s\", got \"%s\"", "updated-name", wtmpl.GetName())
 				}
 			},
 		},
@@ -251,13 +251,13 @@ func TestDeleteTemplate(t *testing.T) {
 func TestGetTemplate(t *testing.T) {
 	ctx := context.Background()
 	expectation := func(t *testing.T, input *workflow.Workflow, tinkDB *db.TinkDB) {
-		wID, wName, wData, err := tinkDB.GetTemplate(ctx, map[string]string{"id": input.ID}, false)
+		wtmpl, err := tinkDB.GetTemplate(ctx, map[string]string{"id": input.ID}, false)
 		if err != nil {
 			t.Error(err)
 		}
-		w := workflow.MustParse([]byte(wData))
-		w.ID = wID
-		w.Name = wName
+		w := workflow.MustParse([]byte(wtmpl.GetData()))
+		w.ID = wtmpl.GetId()
+		w.Name = wtmpl.GetName()
 		if dif := cmp.Diff(input, w); dif != "" {
 			t.Errorf(dif)
 		}
@@ -353,7 +353,7 @@ func TestGetTemplateWithInvalidID(t *testing.T) {
 	}()
 
 	id := uuid.New().String()
-	_, _, _, err := tinkDB.GetTemplate(ctx, map[string]string{"id": id}, false)
+	_, err := tinkDB.GetTemplate(ctx, map[string]string{"id": id}, false)
 	if err == nil {
 		t.Error("expected error, got nil")
 	}

--- a/db/workflow_test.go
+++ b/db/workflow_test.go
@@ -357,12 +357,12 @@ func TestGetWorkflow(t *testing.T) {
 }
 
 func createWorkflow(ctx context.Context, tinkDB *db.TinkDB, in *input) (string, error) {
-	_, _, tmpData, err := tinkDB.GetTemplate(context.Background(), map[string]string{"id": in.template.ID}, false)
+	wtmpl, err := tinkDB.GetTemplate(context.Background(), map[string]string{"id": in.template.ID}, false)
 	if err != nil {
 		return "", err
 	}
 
-	data, err := workflow.RenderTemplate(in.template.ID, tmpData, []byte(in.devices))
+	data, err := workflow.RenderTemplate(in.template.ID, wtmpl.GetData(), []byte(in.devices))
 	if err != nil {
 		return "", err
 	}

--- a/grpc-server/template.go
+++ b/grpc-server/template.go
@@ -62,7 +62,7 @@ func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*tem
 		"id":   in.GetId(),
 		"name": in.GetName(),
 	}
-	id, n, d, err := s.db.GetTemplate(ctx, fields, false)
+	wtmpl, err := s.db.GetTemplate(ctx, fields, false)
 	s.logger.Info("done " + msg)
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
@@ -72,7 +72,7 @@ func (s *server) GetTemplate(ctx context.Context, in *template.GetRequest) (*tem
 		}
 		l.Error(err)
 	}
-	return &template.WorkflowTemplate{Id: id, Name: n, Data: d}, err
+	return wtmpl, err
 }
 
 // DeleteTemplate implements template.DeleteTemplate

--- a/grpc-server/template_test.go
+++ b/grpc-server/template_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tinkerbell/tink/db/mock"
-	pb "github.com/tinkerbell/tink/protos/template"
+	tb "github.com/tinkerbell/tink/protos/template"
 )
 
 const (
@@ -141,7 +141,7 @@ func TestCreateTemplate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			s := testServer(t, tc.args.db)
-			res, err := s.CreateTemplate(ctx, &pb.WorkflowTemplate{Name: tc.args.name, Data: tc.args.template})
+			res, err := s.CreateTemplate(ctx, &tb.WorkflowTemplate{Name: tc.args.name, Data: tc.args.template})
 			if tc.want.expectedError {
 				assert.Error(t, err)
 			} else {
@@ -157,7 +157,7 @@ func TestGetTemplate(t *testing.T) {
 	type (
 		args struct {
 			db         mock.DB
-			getRequest *pb.GetRequest
+			getRequest *tb.GetRequest
 		}
 	)
 	testCases := map[string]struct {
@@ -173,16 +173,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return templateID1, templateName1, template1, nil
+							return &tb.WorkflowTemplate{
+								Id:   templateID1,
+								Name: templateName1,
+								Data: template1,
+							}, nil
 						}
-						return templateNotFoundID, templateNotFoundName, templateNotFoundTemplate, errors.New("failed to get template")
+						return &tb.WorkflowTemplate{
+							Id:   templateNotFoundID,
+							Name: templateNotFoundName,
+							Data: templateNotFoundTemplate,
+						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Name{Name: templateName1}},
+				getRequest: &tb.GetRequest{GetBy: &tb.GetRequest_Name{Name: templateName1}},
 			},
 			id:   templateID1,
 			name: templateName1,
@@ -196,16 +204,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return templateID1, templateName1, template1, nil
+							return &tb.WorkflowTemplate{
+								Id:   templateID1,
+								Name: templateName1,
+								Data: template1,
+							}, nil
 						}
-						return templateNotFoundID, templateNotFoundName, templateNotFoundTemplate, errors.New("failed to get template")
+						return &tb.WorkflowTemplate{
+							Id:   templateNotFoundID,
+							Name: templateNotFoundName,
+							Data: templateNotFoundTemplate,
+						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Name{Name: templateName2}},
+				getRequest: &tb.GetRequest{GetBy: &tb.GetRequest_Name{Name: templateName2}},
 			},
 			id:   templateNotFoundID,
 			name: templateNotFoundName,
@@ -219,16 +235,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return templateID1, templateName1, template1, nil
+							return &tb.WorkflowTemplate{
+								Id:   templateID1,
+								Name: templateName1,
+								Data: template1,
+							}, nil
 						}
-						return templateNotFoundID, templateNotFoundName, templateNotFoundTemplate, errors.New("failed to get template")
+						return &tb.WorkflowTemplate{
+							Id:   templateNotFoundID,
+							Name: templateNotFoundName,
+							Data: templateNotFoundTemplate,
+						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Id{Id: templateID1}},
+				getRequest: &tb.GetRequest{GetBy: &tb.GetRequest_Id{Id: templateID1}},
 			},
 			id:   templateID1,
 			name: templateName1,
@@ -242,16 +266,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return templateID1, templateName1, template1, nil
+							return &tb.WorkflowTemplate{
+								Id:   templateID1,
+								Name: templateName1,
+								Data: template1,
+							}, nil
 						}
-						return templateNotFoundID, templateNotFoundName, templateNotFoundTemplate, errors.New("failed to get template")
+						return &tb.WorkflowTemplate{
+							Id:   templateNotFoundID,
+							Name: templateNotFoundName,
+							Data: templateNotFoundTemplate,
+						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Id{Id: templateID2}},
+				getRequest: &tb.GetRequest{GetBy: &tb.GetRequest_Id{Id: templateID2}},
 			},
 			id:   templateNotFoundID,
 			name: templateNotFoundName,
@@ -265,16 +297,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return templateID1, templateName1, template1, nil
+							return &tb.WorkflowTemplate{
+								Id:   templateID1,
+								Name: templateName1,
+								Data: template1,
+							}, nil
 						}
-						return templateNotFoundID, templateNotFoundName, templateNotFoundTemplate, errors.New("failed to get template")
+						return &tb.WorkflowTemplate{
+							Id:   templateNotFoundID,
+							Name: templateNotFoundName,
+							Data: templateNotFoundTemplate,
+						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &pb.GetRequest{},
+				getRequest: &tb.GetRequest{},
 			},
 			id:   templateNotFoundID,
 			name: templateNotFoundName,
@@ -288,13 +328,21 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return templateID1, templateName1, template1, nil
+							return &tb.WorkflowTemplate{
+								Id:   templateID1,
+								Name: templateName1,
+								Data: template1,
+							}, nil
 						}
-						return templateNotFoundID, templateNotFoundName, templateNotFoundTemplate, errors.New("failed to get template")
+						return &tb.WorkflowTemplate{
+							Id:   templateNotFoundID,
+							Name: templateNotFoundName,
+							Data: templateNotFoundTemplate,
+						}, errors.New("failed to get template")
 					},
 				},
 			},

--- a/grpc-server/template_test.go
+++ b/grpc-server/template_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tinkerbell/tink/db/mock"
-	tb "github.com/tinkerbell/tink/protos/template"
+	pb "github.com/tinkerbell/tink/protos/template"
 )
 
 const (
@@ -141,7 +141,7 @@ func TestCreateTemplate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			s := testServer(t, tc.args.db)
-			res, err := s.CreateTemplate(ctx, &tb.WorkflowTemplate{Name: tc.args.name, Data: tc.args.template})
+			res, err := s.CreateTemplate(ctx, &pb.WorkflowTemplate{Name: tc.args.name, Data: tc.args.template})
 			if tc.want.expectedError {
 				assert.Error(t, err)
 			} else {
@@ -157,7 +157,7 @@ func TestGetTemplate(t *testing.T) {
 	type (
 		args struct {
 			db         mock.DB
-			getRequest *tb.GetRequest
+			getRequest *pb.GetRequest
 		}
 	)
 	testCases := map[string]struct {
@@ -173,24 +173,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*pb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return &tb.WorkflowTemplate{
+							return &pb.WorkflowTemplate{
 								Id:   templateID1,
 								Name: templateName1,
 								Data: template1,
 							}, nil
 						}
-						return &tb.WorkflowTemplate{
+						return &pb.WorkflowTemplate{
 							Id:   templateNotFoundID,
 							Name: templateNotFoundName,
 							Data: templateNotFoundTemplate,
 						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &tb.GetRequest{GetBy: &tb.GetRequest_Name{Name: templateName1}},
+				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Name{Name: templateName1}},
 			},
 			id:   templateID1,
 			name: templateName1,
@@ -204,24 +204,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*pb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return &tb.WorkflowTemplate{
+							return &pb.WorkflowTemplate{
 								Id:   templateID1,
 								Name: templateName1,
 								Data: template1,
 							}, nil
 						}
-						return &tb.WorkflowTemplate{
+						return &pb.WorkflowTemplate{
 							Id:   templateNotFoundID,
 							Name: templateNotFoundName,
 							Data: templateNotFoundTemplate,
 						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &tb.GetRequest{GetBy: &tb.GetRequest_Name{Name: templateName2}},
+				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Name{Name: templateName2}},
 			},
 			id:   templateNotFoundID,
 			name: templateNotFoundName,
@@ -235,24 +235,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*pb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return &tb.WorkflowTemplate{
+							return &pb.WorkflowTemplate{
 								Id:   templateID1,
 								Name: templateName1,
 								Data: template1,
 							}, nil
 						}
-						return &tb.WorkflowTemplate{
+						return &pb.WorkflowTemplate{
 							Id:   templateNotFoundID,
 							Name: templateNotFoundName,
 							Data: templateNotFoundTemplate,
 						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &tb.GetRequest{GetBy: &tb.GetRequest_Id{Id: templateID1}},
+				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Id{Id: templateID1}},
 			},
 			id:   templateID1,
 			name: templateName1,
@@ -266,24 +266,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*pb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return &tb.WorkflowTemplate{
+							return &pb.WorkflowTemplate{
 								Id:   templateID1,
 								Name: templateName1,
 								Data: template1,
 							}, nil
 						}
-						return &tb.WorkflowTemplate{
+						return &pb.WorkflowTemplate{
 							Id:   templateNotFoundID,
 							Name: templateNotFoundName,
 							Data: templateNotFoundTemplate,
 						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &tb.GetRequest{GetBy: &tb.GetRequest_Id{Id: templateID2}},
+				getRequest: &pb.GetRequest{GetBy: &pb.GetRequest_Id{Id: templateID2}},
 			},
 			id:   templateNotFoundID,
 			name: templateNotFoundName,
@@ -297,24 +297,24 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*pb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return &tb.WorkflowTemplate{
+							return &pb.WorkflowTemplate{
 								Id:   templateID1,
 								Name: templateName1,
 								Data: template1,
 							}, nil
 						}
-						return &tb.WorkflowTemplate{
+						return &pb.WorkflowTemplate{
 							Id:   templateNotFoundID,
 							Name: templateNotFoundName,
 							Data: templateNotFoundTemplate,
 						}, errors.New("failed to get template")
 					},
 				},
-				getRequest: &tb.GetRequest{},
+				getRequest: &pb.GetRequest{},
 			},
 			id:   templateNotFoundID,
 			name: templateNotFoundName,
@@ -328,17 +328,17 @@ func TestGetTemplate(t *testing.T) {
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*pb.WorkflowTemplate, error) {
 						t.Log("in get template func")
 
 						if fields["id"] == templateID1 || fields["name"] == templateName1 {
-							return &tb.WorkflowTemplate{
+							return &pb.WorkflowTemplate{
 								Id:   templateID1,
 								Name: templateName1,
 								Data: template1,
 							}, nil
 						}
-						return &tb.WorkflowTemplate{
+						return &pb.WorkflowTemplate{
 							Id:   templateNotFoundID,
 							Name: templateNotFoundName,
 							Data: templateNotFoundTemplate,

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -37,11 +37,11 @@ func (s *server) CreateWorkflow(ctx context.Context, in *workflow.CreateRequest)
 	fields := map[string]string{
 		"id": in.GetTemplate(),
 	}
-	_, _, templateData, err := s.db.GetTemplate(ctx, fields, false)
+	wtmpl, err := s.db.GetTemplate(ctx, fields, false)
 	if err != nil {
 		return &workflow.CreateResponse{}, errors.Wrapf(err, errFailedToGetTemplate, in.GetTemplate())
 	}
-	data, err := wkf.RenderTemplate(in.GetTemplate(), templateData, []byte(in.Hardware))
+	data, err := wkf.RenderTemplate(in.GetTemplate(), wtmpl.GetData(), []byte(in.Hardware))
 
 	if err != nil {
 		metrics.CacheErrors.With(labels).Inc()
@@ -99,11 +99,11 @@ func (s *server) GetWorkflow(ctx context.Context, in *workflow.GetRequest) (*wor
 	fields := map[string]string{
 		"id": w.Template,
 	}
-	_, _, templateData, err := s.db.GetTemplate(ctx, fields, true)
+	wtmpl, err := s.db.GetTemplate(ctx, fields, true)
 	if err != nil {
 		return &workflow.Workflow{}, errors.Wrapf(err, errFailedToGetTemplate, w.Template)
 	}
-	data, err := wkf.RenderTemplate(w.Template, templateData, []byte(w.Hardware))
+	data, err := wkf.RenderTemplate(w.Template, wtmpl.GetData(), []byte(w.Hardware))
 	if err != nil {
 		return &workflow.Workflow{}, err
 	}

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -109,11 +109,13 @@ func (s *server) GetWorkflow(ctx context.Context, in *workflow.GetRequest) (*wor
 	}
 
 	wf := &workflow.Workflow{
-		Id:       w.ID,
-		Template: w.Template,
-		Hardware: w.Hardware,
-		State:    getWorkflowState(s.db, ctx, in.Id),
-		Data:     data,
+		Id:        w.ID,
+		Template:  w.Template,
+		Hardware:  w.Hardware,
+		State:     getWorkflowState(s.db, ctx, in.Id),
+		CreatedAt: w.CreatedAt,
+		UpdatedAt: w.UpdatedAt,
+		Data:      data,
 	}
 	l := s.logger.With("workflowID", w.ID)
 	l.Info("done " + msg)

--- a/grpc-server/workflow_test.go
+++ b/grpc-server/workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tinkerbell/tink/db"
 	"github.com/tinkerbell/tink/db/mock"
+	tb "github.com/tinkerbell/tink/protos/template"
 	"github.com/tinkerbell/tink/protos/workflow"
 )
 
@@ -44,8 +45,12 @@ func TestCreateWorkflow(t *testing.T) {
 		"FailedToGetTemplate": {
 			args: args{
 				db: mock.DB{
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
-						return "", "", "", errors.New("failed to get template")
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+						return &tb.WorkflowTemplate{
+							Id:   "",
+							Name: "",
+							Data: "",
+						}, errors.New("failed to get template")
 					},
 				},
 				wfTemplate: templateID,
@@ -58,8 +63,12 @@ func TestCreateWorkflow(t *testing.T) {
 		"FailedCreatingWorkflow": {
 			args: args{
 				db: mock.DB{
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
-						return "", "", templateData, nil
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+						return &tb.WorkflowTemplate{
+							Id:   "",
+							Name: "",
+							Data: templateData,
+						}, nil
 					},
 					CreateWorkflowFunc: func(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error {
 						return errors.New("failed to create a workfow")
@@ -75,8 +84,12 @@ func TestCreateWorkflow(t *testing.T) {
 		"SuccessCreatingWorkflow": {
 			args: args{
 				db: mock.DB{
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
-						return "", "", templateData, nil
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+						return &tb.WorkflowTemplate{
+							Id:   "",
+							Name: "",
+							Data: templateData,
+						}, nil
 					},
 					CreateWorkflowFunc: func(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error {
 						return nil
@@ -145,8 +158,12 @@ func TestGetWorkflow(t *testing.T) {
 							TotalNumberOfActions: 1,
 						}, nil
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
-						return "", "", templateData, nil
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+						return &tb.WorkflowTemplate{
+							Id:   "",
+							Name: "",
+							Data: templateData,
+						}, nil
 					},
 				},
 				state:      workflow.State_STATE_SUCCESS,
@@ -186,8 +203,12 @@ func TestGetWorkflow(t *testing.T) {
 							TotalNumberOfActions: 2,
 						}, nil
 					},
-					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
-						return "", "", templateData, nil
+					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
+						return &tb.WorkflowTemplate{
+							Id:   "",
+							Name: "",
+							Data: templateData,
+						}, nil
 					},
 				},
 				state:      workflow.State_STATE_RUNNING,


### PR DESCRIPTION
Signed-off-by: parauliya <aman@infracloud.io>

## Description

After this change the value of `createdAt` and `updatedAt` will be correct in the output of `tink template/workflow get <id>` command.

## Why is this needed
Fixes: #475 

## How Has This Been Tested?
This has been tested manually throgh vagrant setup.

## How are existing users impacted? What migration steps/scripts do we need?

No Impact


## Checklist:

I have:

- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
