### PR TITLE
Add docker image building targets to Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,8 +140,7 @@ jobs:
     - name: ${{ matrix.repository }}
       uses: docker/build-push-action@v2
       with:
-        context: .
-        file: cmd/${{ matrix.binary }}/Dockerfile
+        context: cmd/${{ matrix.binary }}/
         cache-from: type=registry,ref=${{ matrix.repository }}:latest
         push: ${{ startsWith(github.ref, 'refs/heads/master') }}
         tags: ${{ steps.docker-image-tag.outputs.tags }}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 LDFLAGS := -ldflags "-X main.version=$(version)"
 export CGO_ENABLED := 0
 
-all: $(binaries)
+all: $(binaries) ## Build all binaries for host OS and CPU
 
 .PHONY: server $(binaries) cli worker test
 server: $(server)
@@ -33,7 +33,7 @@ worker : $(worker)
 
 crossbinaries := $(addsuffix -linux-,$(binaries))
 crossbinaries := $(crossbinaries:=386) $(crossbinaries:=amd64) $(crossbinaries:=arm64) $(crossbinaries:=armv6) $(crossbinaries:=armv7)
-crosscompile: $(crossbinaries)
+crosscompile: $(crossbinaries) ## Build all binaries for Linux OS and all supported CPU arches
 .PHONY: crosscompile $(crossbinaries)
 
 %-386:   FLAGS=GOOS=linux GOARCH=386
@@ -44,11 +44,11 @@ crosscompile: $(crossbinaries)
 $(binaries) $(crossbinaries):
 	$(FLAGS) go build $(LDFLAGS) -o $@ ./$(@D)
 
-test:
+test: ## Run tests
 	go clean -testcache
 	go test ./... -v
 
-verify:
+verify: ## Run lint like checkers
 	goimports -d .
 	golint ./...
 
@@ -63,3 +63,6 @@ grpc/gen_doc:
 		--doc_out=./doc \
 		--doc_opt=html,index.html \
 		protos/hardware/*.proto protos/template/*.proto protos/workflow/*.proto
+
+help: ## Print this help
+	@grep --no-filename -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sed 's/:.*##/·/' | sort | column -ts '·' -c 120

--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,8 @@
-# Only use the recipes defined in these makefiles
-MAKEFLAGS += --no-builtin-rules
-.SUFFIXES:
-# Delete target files if there's an error
-# This avoids a failure to then skip building on next run if the output is created by shell redirection for example
-# Not really necessary for now, but just good to have already if it becomes necessary later.
-.DELETE_ON_ERROR:
-# Treat the whole recipe as a one shell script/invocation instead of one-per-line
-.ONESHELL:
-# Use bash instead of plain sh
-SHELL := bash
-.SHELLFLAGS := -o pipefail -euc
+all: cli server worker ## Build all binaries for host OS and CPU
 
-server := cmd/tink-server/tink-server
-cli := cmd/tink-cli/tink-cli
-worker := cmd/tink-worker/tink-worker
-binaries := $(server) $(cli) $(worker)
+-include rules.mk
 
-version := $(shell git rev-parse --short HEAD)
-tag := $(shell git tag --points-at HEAD)
-ifneq (,$(tag))
-version := $(tag)-$(version)
-endif
-LDFLAGS := -ldflags "-X main.version=$(version)"
-export CGO_ENABLED := 0
-
-all: $(binaries) ## Build all binaries for host OS and CPU
-
-.PHONY: server $(binaries) cli worker test
-server: $(server)
-cli: $(cli)
-worker : $(worker)
-
-crossbinaries := $(addsuffix -linux-,$(binaries))
-crossbinaries := $(crossbinaries:=386) $(crossbinaries:=amd64) $(crossbinaries:=arm64) $(crossbinaries:=armv6) $(crossbinaries:=armv7)
-crosscompile: $(crossbinaries) ## Build all binaries for Linux OS and all supported CPU arches
-.PHONY: crosscompile $(crossbinaries)
-
-%-386:   FLAGS=GOOS=linux GOARCH=386
-%-amd64: FLAGS=GOOS=linux GOARCH=amd64
-%-arm64: FLAGS=GOOS=linux GOARCH=arm64
-%-armv6: FLAGS=GOOS=linux GOARCH=arm GOARM=6
-%-armv7: FLAGS=GOOS=linux GOARCH=arm GOARM=7
-$(binaries) $(crossbinaries):
-	$(FLAGS) go build $(LDFLAGS) -o $@ ./$(@D)
+crosscompile: $(crossbinaries) ## Build all binaries for Linux and all supported CPU arches
 
 test: ## Run tests
 	go clean -testcache
@@ -51,18 +11,6 @@ test: ## Run tests
 verify: ## Run lint like checkers
 	goimports -d .
 	golint ./...
-
-protos/gen_mock:
-	go generate ./protos/**/*
-	goimports -w ./protos/**/mock.go
-
-grpc/gen_doc:
-	protoc \
-		-I./protos \
-		-I./protos/third_party \
-		--doc_out=./doc \
-		--doc_opt=html,index.html \
-		protos/hardware/*.proto protos/template/*.proto protos/workflow/*.proto
 
 help: ## Print this help
 	@grep --no-filename -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sed 's/:.*##/·/' | sort | column -ts '·' -c 120

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ crosscompile: $(crossbinaries)
 $(binaries) $(crossbinaries):
 	$(FLAGS) go build $(LDFLAGS) -o $@ ./$(@D)
 
-run: cmd/tink-cli/tink-cli-linux-amd64 cmd/tink-server/tink-server-linux-amd64 cmd/tink-worker/tink-worker-linux-amd64
-	docker-compose up -d --build db
-	docker-compose up --build tinkerbell boots
 test:
 	go clean -testcache
 	go test ./... -v

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: cli server worker ## Build all binaries for host OS and CPU
 -include rules.mk
 
 crosscompile: $(crossbinaries) ## Build all binaries for Linux and all supported CPU arches
+images: tink-cli-image tink-server-image tink-worker-image ## Build all docker images
 
 test: ## Run tests
 	go clean -testcache

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ It is comprised of following five major components:
 The workflow engine is comprised of a server and a CLI, which communicates over gRPC.
 The CLI is used to create a workflow and its building blocks: templates and targeted hardware.
 
+## Building
+
+Use `make help` Luke.
+The most interesting targets are `make all` (or just `make`) and `make images`.
+`make all` builds all the binaries for your host OS and CPU to enable running directly.
+`make images` will build all the binaries for Linux/x86_64 and build docker images with them.
+
 ## Workflow
 
 A workflow is a framework responsible for handling flexible, bare metal provisioning, that is...

--- a/cmd/tink-cli/Dockerfile
+++ b/cmd/tink-cli/Dockerfile
@@ -5,4 +5,4 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 RUN apk add --no-cache --update --upgrade ca-certificates
-COPY cmd/tink-cli/tink-cli-linux-${TARGETARCH:-amd64}${TARGETVARIANT} /usr/bin/tink
+COPY tink-cli-linux-${TARGETARCH:-amd64}${TARGETVARIANT} /usr/bin/tink

--- a/cmd/tink-server/Dockerfile
+++ b/cmd/tink-server/Dockerfile
@@ -8,4 +8,4 @@ ARG TARGETVARIANT
 
 RUN apk add --update ca-certificates && \
     apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing cfssl
-COPY cmd/tink-server/tink-server-linux-${TARGETARCH:-amd64}${TARGETVARIANT} /usr/bin/tink-server
+COPY tink-server-linux-${TARGETARCH:-amd64}${TARGETVARIANT} /usr/bin/tink-server

--- a/cmd/tink-worker/Dockerfile
+++ b/cmd/tink-worker/Dockerfile
@@ -5,4 +5,4 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 RUN apk add --no-cache --update --upgrade ca-certificates
-COPY cmd/tink-worker/tink-worker-linux-${TARGETARCH:-amd64}${TARGETVARIANT} /usr/bin/tink-worker
+COPY tink-worker-linux-${TARGETARCH:-amd64}${TARGETVARIANT} /usr/bin/tink-worker

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,9 +1,7 @@
 version: "2.1"
 services:
   tink-server:
-    build:
-      context: ../
-      dockerfile: cmd/tink-server/Dockerfile
+    build: ../cmd/tink-server
     restart: unless-stopped
     environment:
       FACILITY: ${FACILITY:-onprem}
@@ -34,9 +32,7 @@ services:
       - 42114:42114/tcp
 
   tink-server-migration:
-    build:
-      context: ../
-      dockerfile: cmd/tink-server/Dockerfile
+    build: ../cmd/tink-server
     restart: on-failure
     environment:
       ONLY_MIGRATION: "true"
@@ -75,9 +71,7 @@ services:
       retries: 30
 
   tink-cli:
-    build:
-      context: ../
-      dockerfile: cmd/tink-cli/Dockerfile
+    build: ../cmd/tink-cli
     restart: unless-stopped
     environment:
       TINKERBELL_GRPC_AUTHORITY: 127.0.0.1:42113

--- a/rules.mk
+++ b/rules.mk
@@ -1,0 +1,50 @@
+# Only use the recipes defined in these makefiles
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+# Delete target files if there's an error
+# This avoids a failure to then skip building on next run if the output is created by shell redirection for example
+# Not really necessary for now, but just good to have already if it becomes necessary later.
+.DELETE_ON_ERROR:
+# Treat the whole recipe as a one shell script/invocation instead of one-per-line
+.ONESHELL:
+# Use bash instead of plain sh
+SHELL := bash
+.SHELLFLAGS := -o pipefail -euc
+
+binaries := cmd/tink-cli/tink-cli cmd/tink-server/tink-server cmd/tink-worker/tink-worker
+version := $(shell git rev-parse --short HEAD)
+tag := $(shell git tag --points-at HEAD)
+ifneq (,$(tag))
+version := $(tag)-$(version)
+endif
+LDFLAGS := -ldflags "-X main.version=$(version)"
+export CGO_ENABLED := 0
+
+cli: cmd/tink-cli/tink-cli
+server: cmd/tink-server/tink-server
+worker : cmd/tink-worker/tink-worker
+
+.PHONY: server cli worker test $(binaries)
+crossbinaries := $(addsuffix -linux-,$(binaries))
+crossbinaries := $(crossbinaries:=386) $(crossbinaries:=amd64) $(crossbinaries:=arm64) $(crossbinaries:=armv6) $(crossbinaries:=armv7)
+
+.PHONY: crosscompile $(crossbinaries)
+%-386:   FLAGS=GOOS=linux GOARCH=386
+%-amd64: FLAGS=GOOS=linux GOARCH=amd64
+%-arm64: FLAGS=GOOS=linux GOARCH=arm64
+%-armv6: FLAGS=GOOS=linux GOARCH=arm GOARM=6
+%-armv7: FLAGS=GOOS=linux GOARCH=arm GOARM=7
+$(binaries) $(crossbinaries):
+	$(FLAGS) go build $(LDFLAGS) -o $@ ./$(@D)
+
+protos/gen_mock:
+	go generate ./protos/**/*
+	goimports -w ./protos/**/mock.go
+
+grpc/gen_doc:
+	protoc \
+		-I./protos \
+		-I./protos/third_party \
+		--doc_out=./doc \
+		--doc_opt=html,index.html \
+		protos/hardware/*.proto protos/template/*.proto protos/workflow/*.proto

--- a/rules.mk
+++ b/rules.mk
@@ -37,6 +37,14 @@ crossbinaries := $(crossbinaries:=386) $(crossbinaries:=amd64) $(crossbinaries:=
 $(binaries) $(crossbinaries):
 	$(FLAGS) go build $(LDFLAGS) -o $@ ./$(@D)
 
+.PHONY: images tink-cli-image tink-server-image tink-worker-image
+tink-cli-image: cmd/tink-cli/tink-cli-linux-amd64
+	docker build -t tink-cli -f cmd/tink-cli/Dockerfile
+tink-server-image: cmd/tink-server/tink-server-linux-amd64
+	docker build -t tink-server -f cmd/tink-server/Dockerfile
+tink-worker-image: cmd/tink-worker/tink-worker-linux-amd64
+	docker build -t tink-worker -f cmd/tink-worker/Dockerfile
+
 protos/gen_mock:
 	go generate ./protos/**/*
 	goimports -w ./protos/**/mock.go

--- a/rules.mk
+++ b/rules.mk
@@ -39,11 +39,11 @@ $(binaries) $(crossbinaries):
 
 .PHONY: images tink-cli-image tink-server-image tink-worker-image
 tink-cli-image: cmd/tink-cli/tink-cli-linux-amd64
-	docker build -t tink-cli -f cmd/tink-cli/Dockerfile
+	docker build -t tink-cli cmd/tink-cli/
 tink-server-image: cmd/tink-server/tink-server-linux-amd64
-	docker build -t tink-server -f cmd/tink-server/Dockerfile
+	docker build -t tink-server cmd/tink-server/
 tink-worker-image: cmd/tink-worker/tink-worker-linux-amd64
-	docker build -t tink-worker -f cmd/tink-worker/Dockerfile
+	docker build -t tink-worker cmd/tink-worker/
 
 protos/gen_mock:
 	go generate ./protos/**/*


### PR DESCRIPTION
## Description

Adds make targets to build the docker images.

## Why is this needed

Its not very obvious that a user needs to run `make crosscompile` before they can try to build the docker images (as came up in community slack yesterday).
By having a proper target in the Makefile we might avoid this situation entirely.

## How Has This Been Tested?

Ran `make images`

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
