### PR TITLE
Fixed #477 : Corrected state for get and get by id command.

### DIFF
--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -13,14 +13,6 @@ import (
 	wkf "github.com/tinkerbell/tink/workflow"
 )
 
-var state = map[int32]workflow.State{
-	0: workflow.State_STATE_PENDING,
-	1: workflow.State_STATE_RUNNING,
-	2: workflow.State_STATE_FAILED,
-	3: workflow.State_STATE_TIMEOUT,
-	4: workflow.State_STATE_SUCCESS,
-}
-
 const errFailedToGetTemplate = "failed to get template with ID %s"
 
 // CreateWorkflow implements workflow.CreateWorkflow
@@ -115,11 +107,12 @@ func (s *server) GetWorkflow(ctx context.Context, in *workflow.GetRequest) (*wor
 	if err != nil {
 		return &workflow.Workflow{}, err
 	}
+
 	wf := &workflow.Workflow{
 		Id:       w.ID,
 		Template: w.Template,
 		Hardware: w.Hardware,
-		State:    state[w.State],
+		State:    getWorkflowState(s.db, ctx, in.Id),
 		Data:     data,
 	}
 	l := s.logger.With("workflowID", w.ID)
@@ -181,6 +174,7 @@ func (s *server) ListWorkflows(_ *workflow.Empty, stream workflow.WorkflowServic
 			Hardware:  w.Hardware,
 			CreatedAt: w.CreatedAt,
 			UpdatedAt: w.UpdatedAt,
+			State:     getWorkflowState(s.db, stream.Context(), w.ID),
 		}
 		return stream.Send(wf)
 	})
@@ -278,4 +272,18 @@ func (s *server) ShowWorkflowEvents(req *workflow.GetRequest, stream workflow.Wo
 	s.logger.Info("done listing workflows events")
 	metrics.CacheHits.With(labels).Inc()
 	return nil
+}
+
+func getWorkflowState(db db.Database, ctx context.Context, id string) workflow.State {
+	wfctx, _ := db.GetWorkflowContexts(ctx, id)
+	if wfctx.CurrentActionState != workflow.State_STATE_SUCCESS {
+		return wfctx.CurrentActionState
+	} else {
+		wfacts, _ := db.GetWorkflowActions(ctx, id)
+		if isLastAction(wfctx, wfacts) {
+			return workflow.State_STATE_SUCCESS
+		} else {
+			return workflow.State_STATE_RUNNING
+		}
+	}
 }

--- a/grpc-server/workflow.go
+++ b/grpc-server/workflow.go
@@ -275,7 +275,7 @@ func (s *server) ShowWorkflowEvents(req *workflow.GetRequest, stream workflow.Wo
 }
 
 // This function will provide the workflow state on the basis of the state of the actions
-// For e.g. : If an action has Tailed or Timeout then the workflow state will also be
+// For e.g. : If an action has Failed or Timeout then the workflow state will also be
 // considered as Failed/Timeout. And If an action is successful then the workflow state
 // will be considered as Running until the last action of the workflow is executed successfully.
 
@@ -284,7 +284,6 @@ func getWorkflowState(db db.Database, ctx context.Context, id string) workflow.S
 	if wfCtx.CurrentActionState != workflow.State_STATE_SUCCESS {
 		return wfCtx.CurrentActionState
 	} else {
-		//wfacts, _ := db.GetWorkflowActions(ctx, id)
 		if wfCtx.GetCurrentActionIndex() == wfCtx.GetTotalNumberOfActions()-1 {
 			return workflow.State_STATE_SUCCESS
 		} else {

--- a/grpc-server/workflow_test.go
+++ b/grpc-server/workflow_test.go
@@ -136,6 +136,14 @@ func TestGetWorkflow(t *testing.T) {
 							Template: templateID,
 							Hardware: hw}, nil
 					},
+					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*workflow.WorkflowContext, error) {
+						return &workflow.WorkflowContext{
+							WorkflowId:           wfID,
+							CurrentActionState:   workflow.State_STATE_SUCCESS,
+							CurrentActionIndex:   0,
+							TotalNumberOfActions: 1,
+						}, nil
+					},
 					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (string, string, string, error) {
 						return "", "", templateData, nil
 					},


### PR DESCRIPTION
Signed-off-by: parauliya <aman@infracloud.io>

## Description
After this Fix user will get the correct state in `tink workflow get` and `tink workflow get <id>` 

## Why is this needed

Fixes: #477 

## How Has This Been Tested?
Tested Manually with Vagrant Setup.

## How are existing users impacted? What migration steps/scripts do we need?
No Impact.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
