### PR TITLE
(bugbash) fixes potential file inclusion via variable.

### DIFF
--- a/cmd/tink-cli/cmd/hardware/push.go
+++ b/cmd/tink-cli/cmd/hardware/push.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -84,7 +85,7 @@ func readDataFromStdin() string {
 }
 
 func readDataFromFile() string {
-	f, err := os.Open(file)
+	f, err := os.Open(filepath.Clean(file))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/tink-cli/cmd/template/create.go
+++ b/cmd/tink-cli/cmd/template/create.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
@@ -39,7 +40,7 @@ $ tink template create --file /tmp/example.tmpl
 			if isInputFromPipe() {
 				reader = os.Stdin
 			} else {
-				f, err := os.Open(filePath)
+				f, err := os.Open(filepath.Clean(filePath))
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/cmd/tink-worker/internal/worker.go
+++ b/cmd/tink-worker/internal/worker.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -473,7 +474,7 @@ func sendUpdate(ctx context.Context, logger log.Logger, client pb.WorkflowServic
 }
 
 func openDataFile(wfDir string, l log.Logger) *os.File {
-	f, err := os.OpenFile(wfDir+string(os.PathSeparator)+dataFile, os.O_RDWR|os.O_CREATE, 0644)
+	f, err := os.OpenFile(filepath.Clean(wfDir+string(os.PathSeparator)+dataFile), os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		l.Error(err)
 		os.Exit(1)

--- a/grpc-server/grpc_server.go
+++ b/grpc-server/grpc_server.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -110,7 +111,7 @@ func getCerts(facility string, logger log.Logger) (tls.Certificate, []byte, time
 		certsDir += "/"
 	}
 
-	certFile, err := os.Open(certsDir + "bundle.pem")
+	certFile, err := os.Open(filepath.Clean(certsDir + "bundle.pem"))
 	if err != nil {
 		err = errors.Wrap(err, "failed to open TLS cert")
 		logger.Error(err)
@@ -131,7 +132,7 @@ func getCerts(facility string, logger log.Logger) (tls.Certificate, []byte, time
 		logger.Error(err)
 		panic(err)
 	}
-	keyPEM, err := ioutil.ReadFile(certsDir + "server-key.pem")
+	keyPEM, err := ioutil.ReadFile(filepath.Clean(certsDir + "server-key.pem"))
 	if err != nil {
 		err = errors.Wrap(err, "failed to read TLS key")
 		logger.Error(err)

--- a/test/framework/hardware.go
+++ b/test/framework/hardware.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/hardware"
 )
 
 func readHwData(file string) ([]byte, error) {
-	f, err := os.Open(file)
+	f, err := os.Open(filepath.Clean(file))
 	if err != nil {
 		return []byte(""), err
 	}

--- a/test/framework/template.go
+++ b/test/framework/template.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/tinkerbell/tink/client"
 	"github.com/tinkerbell/tink/protos/template"
 )
 
 func readTemplateData(file string) (string, error) {
-	f, err := os.Open(file)
+	f, err := os.Open(filepath.Clean(file))
 	if err != nil {
 		return "", err
 	}

--- a/workflow/template_validator.go
+++ b/workflow/template_validator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"text/template"
 
 	"github.com/docker/distribution/reference"
@@ -52,7 +53,7 @@ func MustParse(yamlContent []byte) *Workflow {
 // MustParseFromFile parse a template from a file and it panics if any error is
 // detected. Ideal to be used in testing.
 func MustParseFromFile(path string) *Workflow {
-	content, err := ioutil.ReadFile(path)
+	content, err := ioutil.ReadFile(filepath.Clean(path))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Signed-off-by: Rahul Grover <rahulgrover99@gmail.com>

## Description
gosec was showing the following warning "Potential file inclusion via variable". This is because we are trying to open files using dynamic variables. Hence, I've cleaned the bad file paths using filepath.Clean()
<!--- Please describe what this PR is going to change -->

Fixes: 
G304 Potential file inclusion via variable

