### PR TITLE
upgrade ptypes.TimestampProto to timestamppb.New

### DIFF
--- a/db/template.go
+++ b/db/template.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -14,6 +13,7 @@ import (
 	wflow "github.com/tinkerbell/tink/workflow"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // CreateTemplate creates a new workflow template
@@ -83,8 +83,8 @@ func (d TinkDB) GetTemplate(ctx context.Context, fields map[string]string, delet
 	)
 	err = row.Scan(&id, &name, &data, &createdAt, &updatedAt)
 	if err == nil {
-		crAt, _ := ptypes.TimestampProto(createdAt)
-		upAt, _ := ptypes.TimestampProto(updatedAt)
+		crAt := timestamppb.New(createdAt)
+		upAt := timestamppb.New(updatedAt)
 		return &tb.WorkflowTemplate{
 			Id:        id,
 			Name:      name,
@@ -160,8 +160,8 @@ func (d TinkDB) ListTemplates(filter string, fn func(id, n string, in, del *time
 			return err
 		}
 
-		tCr, _ := ptypes.TimestampProto(createdAt)
-		tUp, _ := ptypes.TimestampProto(updatedAt)
+		tCr := timestamppb.New(createdAt)
+		tUp := timestamppb.New(updatedAt)
 		err = fn(id, name, tCr, tUp)
 		if err != nil {
 			return err

--- a/db/workflow.go
+++ b/db/workflow.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -19,6 +18,7 @@ import (
 	wflow "github.com/tinkerbell/tink/workflow"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Workflow represents a workflow instance in database
@@ -351,8 +351,8 @@ func (d TinkDB) GetWorkflow(ctx context.Context, id string) (Workflow, error) {
 	)
 	err := row.Scan(&tmp, &tar, &crAt, &upAt)
 	if err == nil {
-		createdAt, _ := ptypes.TimestampProto(crAt)
-		updatedAt, _ := ptypes.TimestampProto(upAt)
+		createdAt := timestamppb.New(crAt)
+		updatedAt := timestamppb.New(upAt)
 		return Workflow{
 			ID:        id,
 			Template:  tmp,
@@ -449,8 +449,8 @@ func (d TinkDB) ListWorkflows(fn func(wf Workflow) error) error {
 			Template: tmp,
 			Hardware: tar,
 		}
-		wf.CreatedAt, _ = ptypes.TimestampProto(crAt)
-		wf.UpdatedAt, _ = ptypes.TimestampProto(upAt)
+		wf.CreatedAt = timestamppb.New(crAt)
+		wf.UpdatedAt = timestamppb.New(upAt)
 		err = fn(wf)
 		if err != nil {
 			return err
@@ -645,7 +645,7 @@ func (d TinkDB) ShowWorkflowEvents(wfID string, fn func(wfs *pb.WorkflowActionSt
 			d.logger.Error(err)
 			return err
 		}
-		createdAt, _ := ptypes.TimestampProto(evTime)
+		createdAt := timestamppb.New(evTime)
 		wfs := &pb.WorkflowActionStatus{
 			WorkerId:     id,
 			TaskName:     tName,


### PR DESCRIPTION
Signed-off-by: arcolife <archit.py@gmail.com>

## Description

upgrade `ptypes.TimestampProto` to `timestamppb.New`

## Why is this needed

We're seeing deprecation notices in PRs.

## How has this been tested

- [x] make test