### PR TITLE
remove the ports settings from the boots container docker-compose settings

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -133,10 +133,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    ports:
-      - $TINKERBELL_HOST_IP:80:80/tcp
-      - 67:67/udp
-      - 69:69/udp
 
   nginx:
     image: nginx:alpine


### PR DESCRIPTION
they are not supported when the container uses the host network_mode

this is the error given by docker-compose 1.29.2:

docker.errors.InvalidArgument: "host" network_mode is incompatible with port_binding