### PR TITLE
Fix ineffective assignment in db/mock/template.go

### DIFF
--- a/db/mock/template.go
+++ b/db/mock/template.go
@@ -16,7 +16,7 @@ type Template struct {
 }
 
 // CreateTemplate creates a new workflow template
-func (d DB) CreateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error {
+func (d *DB) CreateTemplate(ctx context.Context, name string, data string, id uuid.UUID) error {
 	if d.TemplateDB == nil {
 		d.TemplateDB = make(map[string]interface{})
 	}
@@ -66,6 +66,6 @@ func (d DB) UpdateTemplate(ctx context.Context, name string, data string, id uui
 }
 
 // ClearTemplateDB clear all the templates
-func (d DB) ClearTemplateDB() {
+func (d *DB) ClearTemplateDB() {
 	d.TemplateDB = make(map[string]interface{})
 }

--- a/grpc-server/template_test.go
+++ b/grpc-server/template_test.go
@@ -54,7 +54,7 @@ tasks:
 func TestCreateTemplate(t *testing.T) {
 	type (
 		args struct {
-			db       mock.DB
+			db       *mock.DB
 			name     string
 			template string
 		}
@@ -68,7 +68,7 @@ func TestCreateTemplate(t *testing.T) {
 	}{
 		"SuccessfulTemplateCreation": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: make(map[string]interface{}),
 				},
 				name:     "template_1",
@@ -81,7 +81,7 @@ func TestCreateTemplate(t *testing.T) {
 
 		"SuccessfulMultipleTemplateCreation": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						"template_1": mock.Template{
 							Data:    template1,
@@ -99,7 +99,7 @@ func TestCreateTemplate(t *testing.T) {
 
 		"FailedMultipleTemplateCreationWithSameName": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						"template_1": mock.Template{
 							Data:    template1,
@@ -117,7 +117,7 @@ func TestCreateTemplate(t *testing.T) {
 
 		"SuccessfulTemplateCreationAfterDeletingWithSameName": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						"template_1": mock.Template{
 							Data:    template1,
@@ -156,7 +156,7 @@ func TestCreateTemplate(t *testing.T) {
 func TestGetTemplate(t *testing.T) {
 	type (
 		args struct {
-			db         mock.DB
+			db         *mock.DB
 			getRequest *pb.GetRequest
 		}
 	)
@@ -169,7 +169,7 @@ func TestGetTemplate(t *testing.T) {
 	}{
 		"SuccessfulTemplateGet_Name": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
@@ -200,7 +200,7 @@ func TestGetTemplate(t *testing.T) {
 
 		"FailedTemplateGet_Name": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
@@ -231,7 +231,7 @@ func TestGetTemplate(t *testing.T) {
 
 		"SuccessfulTemplateGet_ID": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
@@ -262,7 +262,7 @@ func TestGetTemplate(t *testing.T) {
 
 		"FailedTemplateGet_ID": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
@@ -293,7 +293,7 @@ func TestGetTemplate(t *testing.T) {
 
 		"FailedTemplateGet_EmptyRequest": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},
@@ -324,7 +324,7 @@ func TestGetTemplate(t *testing.T) {
 
 		"FailedTemplateGet_NilRequest": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					TemplateDB: map[string]interface{}{
 						templateName1: template1,
 					},

--- a/grpc-server/tinkerbell_test.go
+++ b/grpc-server/tinkerbell_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 func TestGetWorkflowContextList(t *testing.T) {
 	type (
 		args struct {
-			db       mock.DB
+			db       *mock.DB
 			workerID string
 		}
 		want struct {
@@ -58,7 +58,7 @@ func TestGetWorkflowContextList(t *testing.T) {
 	}{
 		"empty worker id": {
 			args: args{
-				db: mock.DB{},
+				db: &mock.DB{},
 			},
 			want: want{
 				expectedError: true,
@@ -66,7 +66,7 @@ func TestGetWorkflowContextList(t *testing.T) {
 		},
 		"database failure": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
 						return []string{workflowID}, nil
 					},
@@ -82,7 +82,7 @@ func TestGetWorkflowContextList(t *testing.T) {
 		},
 		"no workflows found": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
 						return nil, nil
 					},
@@ -98,7 +98,7 @@ func TestGetWorkflowContextList(t *testing.T) {
 		},
 		"workflows found": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
 						return []string{workflowID}, nil
 					},
@@ -144,7 +144,7 @@ func TestGetWorkflowContextList(t *testing.T) {
 func TestGetWorkflowActions(t *testing.T) {
 	type (
 		args struct {
-			db         mock.DB
+			db         *mock.DB
 			workflowID string
 		}
 		want struct {
@@ -157,7 +157,7 @@ func TestGetWorkflowActions(t *testing.T) {
 	}{
 		"empty workflow id": {
 			args: args{
-				db: mock.DB{},
+				db: &mock.DB{},
 			},
 			want: want{
 				expectedError: true,
@@ -165,7 +165,7 @@ func TestGetWorkflowActions(t *testing.T) {
 		},
 		"database failure": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowActionsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowActionList, error) {
 						return nil, errors.New("SELECT from worflow_state")
 					},
@@ -178,7 +178,7 @@ func TestGetWorkflowActions(t *testing.T) {
 		},
 		"getting actions": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowActionsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowActionList, error) {
 						return &pb.WorkflowActionList{
 							ActionList: []*pb.WorkflowAction{
@@ -223,7 +223,7 @@ func TestGetWorkflowActions(t *testing.T) {
 func TestReportActionStatus(t *testing.T) {
 	type (
 		args struct {
-			db                                         mock.DB
+			db                                         *mock.DB
 			workflowID, taskName, actionName, workerID string
 			actionState                                pb.State
 		}
@@ -237,7 +237,7 @@ func TestReportActionStatus(t *testing.T) {
 	}{
 		"empty workflow id": {
 			args: args{
-				db:         mock.DB{},
+				db:         &mock.DB{},
 				taskName:   taskName,
 				actionName: actionName,
 			},
@@ -247,7 +247,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"empty task name": {
 			args: args{
-				db:         mock.DB{},
+				db:         &mock.DB{},
 				workflowID: workflowID,
 				actionName: actionName,
 			},
@@ -257,7 +257,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"empty action name": {
 			args: args{
-				db:         mock.DB{},
+				db:         &mock.DB{},
 				taskName:   taskName,
 				workflowID: workflowID,
 			},
@@ -267,7 +267,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"error getting workflow context": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return nil, errors.New("SELECT from worflow_state")
 					},
@@ -284,7 +284,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"failed getting actions for context": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -308,7 +308,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"success reporting status": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -348,7 +348,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"report status for second action": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -397,7 +397,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"reporting different action name": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -431,7 +431,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"reporting different task name": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -465,7 +465,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"failed to update workflow state": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -502,7 +502,7 @@ func TestReportActionStatus(t *testing.T) {
 		},
 		"failed to update workflow events": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -572,7 +572,7 @@ func TestReportActionStatus(t *testing.T) {
 func TestUpdateWorkflowData(t *testing.T) {
 	type (
 		args struct {
-			db         mock.DB
+			db         *mock.DB
 			data       []byte
 			workflowID string
 		}
@@ -586,7 +586,7 @@ func TestUpdateWorkflowData(t *testing.T) {
 	}{
 		"empty workflow id": {
 			args: args{
-				db: mock.DB{},
+				db: &mock.DB{},
 			},
 			want: want{
 				expectedError: true,
@@ -594,7 +594,7 @@ func TestUpdateWorkflowData(t *testing.T) {
 		},
 		"database failure": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					InsertIntoWfDataTableFunc: func(ctx context.Context, req *pb.UpdateWorkflowDataRequest) error {
 						return errors.New("INSERT Into workflow_data")
 					},
@@ -608,7 +608,7 @@ func TestUpdateWorkflowData(t *testing.T) {
 		},
 		"add new data": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					InsertIntoWfDataTableFunc: func(ctx context.Context, req *pb.UpdateWorkflowDataRequest) error {
 						return nil
 					},
@@ -644,7 +644,7 @@ func TestUpdateWorkflowData(t *testing.T) {
 func TestGetWorkflowData(t *testing.T) {
 	type (
 		args struct {
-			db         mock.DB
+			db         *mock.DB
 			workflowID string
 		}
 		want struct {
@@ -658,7 +658,7 @@ func TestGetWorkflowData(t *testing.T) {
 	}{
 		"empty workflow id": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetfromWfDataTableFunc: func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error) {
 						return []byte{}, nil
 					},
@@ -672,7 +672,7 @@ func TestGetWorkflowData(t *testing.T) {
 		},
 		"invalid workflow id": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetfromWfDataTableFunc: func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error) {
 						return []byte{}, errors.New("invalid uuid")
 					},
@@ -686,7 +686,7 @@ func TestGetWorkflowData(t *testing.T) {
 		},
 		"no workflow data": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetfromWfDataTableFunc: func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error) {
 						return []byte{}, nil
 					},
@@ -699,7 +699,7 @@ func TestGetWorkflowData(t *testing.T) {
 		},
 		"workflow data": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetfromWfDataTableFunc: func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error) {
 						return wfData, nil
 					},
@@ -734,7 +734,7 @@ func TestGetWorkflowData(t *testing.T) {
 func TestGetWorkflowsForWorker(t *testing.T) {
 	type (
 		args struct {
-			db       mock.DB
+			db       *mock.DB
 			workerID string
 		}
 		want struct {
@@ -748,7 +748,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 	}{
 		"empty workflow id": {
 			args: args{
-				db:       mock.DB{},
+				db:       &mock.DB{},
 				workerID: "",
 			},
 			want: want{
@@ -757,7 +757,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 		},
 		"database failure": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
 						return nil, errors.New("database failed")
 					},
@@ -770,7 +770,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 		},
 		"no workflows found": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
 						return nil, nil
 					},
@@ -783,7 +783,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 		},
 		"workflows found": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
 						return []string{workflowID}, nil
 					},
@@ -815,7 +815,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 func TestGetWorkflowMetadata(t *testing.T) {
 	type (
 		args struct {
-			db         mock.DB
+			db         *mock.DB
 			workflowID string
 		}
 		want struct {
@@ -828,7 +828,7 @@ func TestGetWorkflowMetadata(t *testing.T) {
 	}{
 		"database failure": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowMetadataFunc: func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error) {
 						return []byte{}, errors.New("SELECT from workflow_data")
 					},
@@ -841,7 +841,7 @@ func TestGetWorkflowMetadata(t *testing.T) {
 		},
 		"no metadata": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowMetadataFunc: func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error) {
 						return []byte{}, nil
 					},
@@ -854,7 +854,7 @@ func TestGetWorkflowMetadata(t *testing.T) {
 		},
 		"metadata": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowMetadataFunc: func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error) {
 						type workflowMetadata struct {
 							WorkerID  string    `json:"worker-id"`
@@ -914,7 +914,7 @@ func TestGetWorkflowMetadata(t *testing.T) {
 func TestGetWorkflowDataVersion(t *testing.T) {
 	type (
 		args struct {
-			db mock.DB
+			db *mock.DB
 		}
 		want struct {
 			version       int32
@@ -927,7 +927,7 @@ func TestGetWorkflowDataVersion(t *testing.T) {
 	}{
 		"database failure": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowDataVersionFunc: func(ctx context.Context, workflowID string) (int32, error) {
 						return -1, errors.New("SELECT from workflow_data")
 					},
@@ -940,7 +940,7 @@ func TestGetWorkflowDataVersion(t *testing.T) {
 		},
 		"success": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowDataVersionFunc: func(ctx context.Context, workflowID string) (int32, error) {
 						return 2, nil
 					},
@@ -973,7 +973,7 @@ func TestGetWorkflowDataVersion(t *testing.T) {
 func TestIsApplicableToSend(t *testing.T) {
 	type (
 		args struct {
-			db mock.DB
+			db *mock.DB
 		}
 		want struct {
 			isApplicable bool
@@ -985,7 +985,7 @@ func TestIsApplicableToSend(t *testing.T) {
 	}{
 		"failed state": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -1001,7 +1001,7 @@ func TestIsApplicableToSend(t *testing.T) {
 		},
 		"timeout state": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -1017,7 +1017,7 @@ func TestIsApplicableToSend(t *testing.T) {
 		},
 		"failed to get actions": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -1036,7 +1036,7 @@ func TestIsApplicableToSend(t *testing.T) {
 		},
 		"is last action and success state": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -1065,7 +1065,7 @@ func TestIsApplicableToSend(t *testing.T) {
 		},
 		"in-progress last action for different worker": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -1094,7 +1094,7 @@ func TestIsApplicableToSend(t *testing.T) {
 		},
 		"success state and not the last action": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -1130,7 +1130,7 @@ func TestIsApplicableToSend(t *testing.T) {
 		},
 		"not the last action": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -1182,7 +1182,7 @@ func TestIsApplicableToSend(t *testing.T) {
 func TestIsLastAction(t *testing.T) {
 	type (
 		args struct {
-			db mock.DB
+			db *mock.DB
 		}
 		want struct {
 			isLastAction bool
@@ -1194,7 +1194,7 @@ func TestIsLastAction(t *testing.T) {
 	}{
 		"is not last": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,
@@ -1230,7 +1230,7 @@ func TestIsLastAction(t *testing.T) {
 		},
 		"is last": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
 						return &pb.WorkflowContext{
 							WorkflowId:           workflowID,

--- a/grpc-server/workflow_test.go
+++ b/grpc-server/workflow_test.go
@@ -31,7 +31,7 @@ tasks:
 func TestCreateWorkflow(t *testing.T) {
 	type (
 		args struct {
-			db                     mock.DB
+			db                     *mock.DB
 			wfTemplate, wfHardware string
 		}
 		want struct {
@@ -44,7 +44,7 @@ func TestCreateWorkflow(t *testing.T) {
 	}{
 		"FailedToGetTemplate": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						return &tb.WorkflowTemplate{
 							Id:   "",
@@ -62,7 +62,7 @@ func TestCreateWorkflow(t *testing.T) {
 		},
 		"FailedCreatingWorkflow": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						return &tb.WorkflowTemplate{
 							Id:   "",
@@ -83,7 +83,7 @@ func TestCreateWorkflow(t *testing.T) {
 		},
 		"SuccessCreatingWorkflow": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetTemplateFunc: func(ctx context.Context, fields map[string]string, deleted bool) (*tb.WorkflowTemplate, error) {
 						return &tb.WorkflowTemplate{
 							Id:   "",
@@ -129,7 +129,7 @@ func TestCreateWorkflow(t *testing.T) {
 func TestGetWorkflow(t *testing.T) {
 	type (
 		args struct {
-			db                     mock.DB
+			db                     *mock.DB
 			wfTemplate, wfHardware string
 			state                  workflow.State
 		}
@@ -143,7 +143,7 @@ func TestGetWorkflow(t *testing.T) {
 	}{
 		"SuccessGettingWorkflow": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowFunc: func(ctx context.Context, workflowID string) (db.Workflow, error) {
 						return db.Workflow{
 							ID:       workflowID,
@@ -176,7 +176,7 @@ func TestGetWorkflow(t *testing.T) {
 		},
 		"WorkflowDoesNotExist": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowFunc: func(ctx context.Context, workflowID string) (db.Workflow, error) {
 						return db.Workflow{}, errors.New("Workflow with id " + workflowID + " does not exist")
 					},
@@ -188,7 +188,7 @@ func TestGetWorkflow(t *testing.T) {
 		},
 		"GetWorkflowState": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowFunc: func(ctx context.Context, workflowID string) (db.Workflow, error) {
 						return db.Workflow{
 							ID:       workflowID,
@@ -246,7 +246,7 @@ func TestGetWorkflow(t *testing.T) {
 func TestGetWorkflowContext(t *testing.T) {
 	type (
 		args struct {
-			db mock.DB
+			db *mock.DB
 		}
 		want struct {
 			expectedError bool
@@ -258,7 +258,7 @@ func TestGetWorkflowContext(t *testing.T) {
 	}{
 		"WorkflowDoesNotExist": {
 			args: args{
-				db: mock.DB{
+				db: &mock.DB{
 					GetWorkflowContextsFunc: func(ctx context.Context, workflowID string) (*workflow.WorkflowContext, error) {
 						w := workflow.WorkflowContext{}
 						return &w, errors.New("Workflow with id " + workflowID + " does not exist")


### PR DESCRIPTION
## Description

While updating and rebasing #266, I noticed that golangci-lint was finding a new issue in our db mocking library. This PR addresses that issue

## How Has This Been Tested?

I verified tests continued to work after updating the receiver type of the methods that modified the mock db variable.

## How are existing users impacted? What migration steps/scripts do we need?

This change only impacts tests and no migrations are needed.
