### PR TITLE
Fix handling of os signals in tink server

### DIFF
--- a/cmd/tink-server/main.go
+++ b/cmd/tink-server/main.go
@@ -191,12 +191,12 @@ func NewRootCommand(config *DaemonConfig, logger log.Logger) *cobra.Command {
 				HTTPBasicAuthPassword: config.HTTPBasicAuthPassword,
 			}, errCh)
 
-			<-ctx.Done()
 			select {
 			case err = <-errCh:
 				logger.Error(err)
 			case sig := <-sigs:
 				logger.With("signal", sig.String()).Info("signal received, stopping servers")
+				closer()
 			}
 
 			// wait for grpc server to shutdown


### PR DESCRIPTION
Related to #527

## Description

Previously tink server failed to respect os signals like SIGTERM,SIGINT etc.

This PR fixes the tink server so that os signals sent to the tink server process
will actually kill the process.

## Why is this needed

Sending os signals actually terminates the tink server.

Fixes: #527

## How Has This Been Tested?
- Tested using docker-compose:

```bash
make images
make run
docker exec -it tink_tinkerbell_1 sh
ps
kill -SIGINT 1
```

Corresponding logs:

```
tinkerbell_1             | {"level":"info","ts":1630442128.6128566,"caller":"tink-server/main.go:198","msg":"signal received, stopping servers","service":"github.com/tinkerbell/tink","signal":"interrupt"}
tinkerbell_1             | {"level":"info","ts":1630442129.4250214,"caller":"metrics/metrics.go:58","msg":"initializing label values","service":"github.com/tinkerbell/tink"}
tinkerbell_1             | {"level":"info","ts":1630442129.4286315,"caller":"http-server/http_server.go:88","msg":"serving http","service":"github.com/tinkerbell/tink"}
```

Now the docker container exists and we can see the log that signal is received.

Signed-off-by: Archana krishnan <krisharchana9@gmail.com>