### PR TITLE
Database interface refactor

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -22,6 +22,7 @@ type Database interface {
 	hardware
 	template
 	workflow
+	WorkerWorkflow
 }
 
 type hardware interface {
@@ -43,20 +44,24 @@ type template interface {
 
 type workflow interface {
 	CreateWorkflow(ctx context.Context, wf Workflow, data string, id uuid.UUID) error
-	InsertIntoWfDataTable(ctx context.Context, req *pb.UpdateWorkflowDataRequest) error
-	GetfromWfDataTable(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error)
 	GetWorkflowMetadata(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error)
 	GetWorkflowDataVersion(ctx context.Context, workflowID string) (int32, error)
 	GetWorkflow(ctx context.Context, id string) (Workflow, error)
 	DeleteWorkflow(ctx context.Context, id string, state int32) error
 	ListWorkflows(fn func(wf Workflow) error) error
 	UpdateWorkflow(ctx context.Context, wf Workflow, state int32) error
+	InsertIntoWorkflowEventTable(ctx context.Context, wfEvent *pb.WorkflowActionStatus, time time.Time) error
+	ShowWorkflowEvents(wfID string, fn func(wfs *pb.WorkflowActionStatus) error) error
+}
+
+// WorkerWorkflow is an interface for methods invoked by APIs that the worker calls
+type WorkerWorkflow interface {
+	InsertIntoWfDataTable(ctx context.Context, req *pb.UpdateWorkflowDataRequest) error
+	GetfromWfDataTable(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error)
 	GetWorkflowsForWorker(ctx context.Context, id string) ([]string, error)
 	UpdateWorkflowState(ctx context.Context, wfContext *pb.WorkflowContext) error
 	GetWorkflowContexts(ctx context.Context, wfID string) (*pb.WorkflowContext, error)
 	GetWorkflowActions(ctx context.Context, wfID string) (*pb.WorkflowActionList, error)
-	InsertIntoWorkflowEventTable(ctx context.Context, wfEvent *pb.WorkflowActionStatus, time time.Time) error
-	ShowWorkflowEvents(wfID string, fn func(wfs *pb.WorkflowActionStatus) error) error
 }
 
 // TinkDB implements the Database interface

--- a/db/db.go
+++ b/db/db.go
@@ -47,11 +47,11 @@ type workflow interface {
 	GetfromWfDataTable(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error)
 	GetWorkflowMetadata(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error)
 	GetWorkflowDataVersion(ctx context.Context, workflowID string) (int32, error)
-	GetWorkflowsForWorker(id string) ([]string, error)
 	GetWorkflow(ctx context.Context, id string) (Workflow, error)
 	DeleteWorkflow(ctx context.Context, id string, state int32) error
 	ListWorkflows(fn func(wf Workflow) error) error
 	UpdateWorkflow(ctx context.Context, wf Workflow, state int32) error
+	GetWorkflowsForWorker(ctx context.Context, id string) ([]string, error)
 	UpdateWorkflowState(ctx context.Context, wfContext *pb.WorkflowContext) error
 	GetWorkflowContexts(ctx context.Context, wfID string) (*pb.WorkflowContext, error)
 	GetWorkflowActions(ctx context.Context, wfID string) (*pb.WorkflowActionList, error)

--- a/db/mock/mock.go
+++ b/db/mock/mock.go
@@ -19,7 +19,7 @@ type DB struct {
 	InsertIntoWfDataTableFunc        func(ctx context.Context, req *pb.UpdateWorkflowDataRequest) error
 	GetWorkflowMetadataFunc          func(ctx context.Context, req *pb.GetWorkflowDataRequest) ([]byte, error)
 	GetWorkflowDataVersionFunc       func(ctx context.Context, workflowID string) (int32, error)
-	GetWorkflowsForWorkerFunc        func(id string) ([]string, error)
+	GetWorkflowsForWorkerFunc        func(ctx context.Context, id string) ([]string, error)
 	GetWorkflowContextsFunc          func(ctx context.Context, wfID string) (*pb.WorkflowContext, error)
 	GetWorkflowActionsFunc           func(ctx context.Context, wfID string) (*pb.WorkflowActionList, error)
 	UpdateWorkflowStateFunc          func(ctx context.Context, wfContext *pb.WorkflowContext) error

--- a/db/mock/workflow.go
+++ b/db/mock/workflow.go
@@ -35,8 +35,8 @@ func (d DB) GetWorkflowDataVersion(ctx context.Context, workflowID string) (int3
 }
 
 // GetWorkflowsForWorker : returns the list of workflows for a particular worker
-func (d DB) GetWorkflowsForWorker(id string) ([]string, error) {
-	return d.GetWorkflowsForWorkerFunc(id)
+func (d DB) GetWorkflowsForWorker(ctx context.Context, id string) ([]string, error) {
+	return d.GetWorkflowsForWorkerFunc(ctx, id)
 }
 
 // GetWorkflow returns a workflow

--- a/db/workflow.go
+++ b/db/workflow.go
@@ -304,8 +304,8 @@ func (d TinkDB) GetWorkflowDataVersion(ctx context.Context, workflowID string) (
 }
 
 // GetWorkflowsForWorker : returns the list of workflows for a particular worker
-func (d TinkDB) GetWorkflowsForWorker(id string) ([]string, error) {
-	rows, err := d.instance.Query(`
+func (d TinkDB) GetWorkflowsForWorker(ctx context.Context, id string) ([]string, error) {
+	rows, err := d.instance.QueryContext(ctx, `
 	SELECT workflow_id
 	FROM workflow_worker_map
 	WHERE

--- a/grpc-server/tinkerbell.go
+++ b/grpc-server/tinkerbell.go
@@ -30,7 +30,7 @@ const (
 
 // GetWorkflowContexts implements tinkerbell.GetWorkflowContexts
 func (s *server) GetWorkflowContexts(req *pb.WorkflowContextRequest, stream pb.WorkflowService_GetWorkflowContextsServer) error {
-	wfs, err := getWorkflowsForWorker(s.db, req.WorkerId)
+	wfs, err := getWorkflowsForWorker(stream.Context(), s.db, req.WorkerId)
 	if err != nil {
 		return err
 	}
@@ -49,8 +49,8 @@ func (s *server) GetWorkflowContexts(req *pb.WorkflowContextRequest, stream pb.W
 }
 
 // GetWorkflowContextList implements tinkerbell.GetWorkflowContextList
-	wfs, err := getWorkflowsForWorker(s.db, req.WorkerId)
 func (s *server) GetWorkflowContextList(ctx context.Context, req *pb.WorkflowContextRequest) (*pb.WorkflowContextList, error) {
+	wfs, err := getWorkflowsForWorker(ctx, s.db, req.WorkerId)
 	if err != nil {
 		return nil, err
 	}
@@ -196,11 +196,11 @@ func (s *server) GetWorkflowDataVersion(ctx context.Context, req *pb.GetWorkflow
 	return &pb.GetWorkflowDataResponse{Version: version}, nil
 }
 
-func getWorkflowsForWorker(db db.Database, id string) ([]string, error) {
+func getWorkflowsForWorker(ctx context.Context, db db.Database, id string) ([]string, error) {
 	if id == "" {
 		return nil, status.Errorf(codes.InvalidArgument, errInvalidWorkerID)
 	}
-	wfs, err := db.GetWorkflowsForWorker(id)
+	wfs, err := db.GetWorkflowsForWorker(ctx, id)
 	if err != nil {
 		return nil, status.Errorf(codes.Aborted, err.Error())
 	}

--- a/grpc-server/tinkerbell.go
+++ b/grpc-server/tinkerbell.go
@@ -35,11 +35,11 @@ func (s *server) GetWorkflowContexts(req *pb.WorkflowContextRequest, stream pb.W
 		return err
 	}
 	for _, wf := range wfs {
-		wfContext, err := s.db.GetWorkflowContexts(context.Background(), wf)
+		wfContext, err := s.db.GetWorkflowContexts(stream.Context(), wf)
 		if err != nil {
 			return status.Errorf(codes.Aborted, err.Error())
 		}
-		if isApplicableToSend(context.Background(), s.logger, wfContext, req.WorkerId, s.db) {
+		if isApplicableToSend(stream.Context(), s.logger, wfContext, req.WorkerId, s.db) {
 			if err := stream.Send(wfContext); err != nil {
 				return err
 			}

--- a/grpc-server/tinkerbell_test.go
+++ b/grpc-server/tinkerbell_test.go
@@ -67,7 +67,7 @@ func TestGetWorkflowContextList(t *testing.T) {
 		"database failure": {
 			args: args{
 				db: &mock.DB{
-					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
+					GetWorkflowsForWorkerFunc: func(ctx context.Context, id string) ([]string, error) {
 						return []string{workflowID}, nil
 					},
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
@@ -83,7 +83,7 @@ func TestGetWorkflowContextList(t *testing.T) {
 		"no workflows found": {
 			args: args{
 				db: &mock.DB{
-					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
+					GetWorkflowsForWorkerFunc: func(ctx context.Context, id string) ([]string, error) {
 						return nil, nil
 					},
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
@@ -99,7 +99,7 @@ func TestGetWorkflowContextList(t *testing.T) {
 		"workflows found": {
 			args: args{
 				db: &mock.DB{
-					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
+					GetWorkflowsForWorkerFunc: func(ctx context.Context, id string) ([]string, error) {
 						return []string{workflowID}, nil
 					},
 					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
@@ -758,7 +758,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 		"database failure": {
 			args: args{
 				db: &mock.DB{
-					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
+					GetWorkflowsForWorkerFunc: func(ctx context.Context, id string) ([]string, error) {
 						return nil, errors.New("database failed")
 					},
 				},
@@ -771,7 +771,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 		"no workflows found": {
 			args: args{
 				db: &mock.DB{
-					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
+					GetWorkflowsForWorkerFunc: func(ctx context.Context, id string) ([]string, error) {
 						return nil, nil
 					},
 				},
@@ -784,7 +784,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 		"workflows found": {
 			args: args{
 				db: &mock.DB{
-					GetWorkflowsForWorkerFunc: func(id string) ([]string, error) {
+					GetWorkflowsForWorkerFunc: func(ctx context.Context, id string) ([]string, error) {
 						return []string{workflowID}, nil
 					},
 				},
@@ -799,7 +799,7 @@ func TestGetWorkflowsForWorker(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			s := testServer(t, tc.args.db)
-			res, err := getWorkflowsForWorker(s.db, tc.args.workerID)
+			res, err := getWorkflowsForWorker(context.Background(), s.db, tc.args.workerID)
 			if err != nil {
 				assert.True(t, tc.want.expectedError)
 				assert.Error(t, err)


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Description

This includes 4 changes that are preparatory for future work to migrate to the Kubernetes data model.

* Propagate stream context in streaming API. Previously `context.Background()` was used, but the stream provides a context object
* Refactored shadowed "context" package name. By naming a method variable "context", no `context` package calls could be made in the method
* Added `context.Context` to `GetWorkflowsForWorker()` database API. This plumbs down the context from the API call into the `d.instance.QueryContext()` call.
* Refactor the database interface. I added a new interface `WorkerWorkflow` with the methods that get used by APIs the Tink Worker invokes. This is essentially a no-op for now. 

## Why is this needed

See tinkerbell/proposals#46

## How Has This Been Tested?

Locally ran tests.

## How are existing users impacted? What migration steps/scripts do we need?

No impact to existing users

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
