### PR TITLE
Increase timeout for golangci-lint and allow parallel runners

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+run:
+  timeout: 2m
+  allow-parallel-runners: true


### PR DESCRIPTION
## Description

Increases the timeout for golangci-lint and configures the use of parallel runners

## Why is this needed

The github action that pushes the latest images was being flaky and would sometimes hit the default timeout of 1m for golangci-lint when running, causing the images to not be published.

## How are existing users impacted? What migration steps/scripts do we need?

This only affects CI and manual runs of golangci-lint, it does not affect end users

