### PR TITLE
set the default retry-interval unit to seconds

### DIFF
--- a/cmd/tink-worker/cmd/root.go
+++ b/cmd/tink-worker/cmd/root.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	defaultRetryInterval        = 3
-	defaultRetryCount           = 3
-	defaultMaxFileSize    int64 = 10 * 1024 * 1024 // 10MB
-	defaultTimeoutMinutes       = 60
+	defaultRetryIntervalSeconds       = 3
+	defaultRetryCount                 = 3
+	defaultMaxFileSize          int64 = 10 * 1024 * 1024 // 10MB
+	defaultTimeoutMinutes             = 60
 )
 
 // NewRootCommand creates a new Tink Worker Cobra root command.
@@ -79,7 +79,7 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 		},
 	}
 
-	rootCmd.Flags().Duration("retry-interval", defaultRetryInterval, "Retry interval in seconds (RETRY_INTERVAL)")
+	rootCmd.Flags().Duration("retry-interval", defaultRetryIntervalSeconds*time.Second, "Retry interval in seconds (RETRY_INTERVAL)")
 
 	rootCmd.Flags().Duration("timeout", defaultTimeoutMinutes*time.Minute, "Max duration to wait for worker to complete (TIMEOUT)")
 


### PR DESCRIPTION
without a unit it was using 3ns instead of 3s

## Description

I've noticed the tink-worker retry-interval was set to 3ns instead of 3s:

![image](https://user-images.githubusercontent.com/43356/136604277-011879cc-8e8b-4313-a84f-403a0f459a1b.png)

## Why is this needed

Its needed to match the documentation and because 3s is a saner value than 3ns.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
