### PR TITLE
Upgrade to PostgreSQL 14

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -27,7 +27,7 @@ func NewPostgresDatabaseClient(ctx context.Context, t *testing.T, req NewPostgre
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 	postgresC, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "postgres:13.1",
+			Image:        "postgres:14-alpine",
 			ExposedPorts: []string{"5432/tcp"},
 			WaitingFor:   wait.ForLog("database system is ready to accept connections"),
 			Env: map[string]string{

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
         condition: service_healthy
 
   db:
-    image: postgres:10-alpine
+    image: postgres:14-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: tinkerbell


### PR DESCRIPTION
## Description

Upgrade to PostgreSQL 14.

## Why is this needed

Besides all the major improvements made from PostgreSQL 10 to 14, there is one particular feature that I wanted to use:

[A nicer way to work with JSON](https://www.postgresql.org/docs/14/datatype-json.html#JSONB-SUBSCRIPTING), like the hardware data model :-)

Fixes: #551

The sandbox MR is at https://github.com/tinkerbell/sandbox/pull/110.

## How Has This Been Tested?

Besides the unit tests executed by CI, I've successfully tested this locally in a sandbox, and PostgreSQL 14 is now running:

```console
root@provisioner:~# docker exec -i compose-db-1 psql -U tinkerbell -A -c 'select version()'
version
PostgreSQL 14.0 on x86_64-pc-linux-musl, compiled by gcc (Alpine 10.3.1_git20210424) 10.3.1 20210424, 64-bit
(1 row)
```

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
