### PR TITLE
Use newer alpine

### DIFF
--- a/cmd/tink-cli/Dockerfile
+++ b/cmd/tink-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.15
 CMD sleep infinity
 
 ARG TARGETARCH

--- a/cmd/tink-server/Dockerfile
+++ b/cmd/tink-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.15
 ENTRYPOINT ["/usr/bin/tink-server"]
 EXPOSE 42113
 EXPOSE 42114

--- a/cmd/tink-worker/Dockerfile
+++ b/cmd/tink-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 ENTRYPOINT [ "/usr/bin/tink-worker" ]
 
 ARG TARGETARCH


### PR DESCRIPTION
Quay.io security scanner reports issues with the busybox in this version
of alpine, use latest

## Description

See quay.io security scanner report for example:

https://quay.io/repository/tinkerbell/tink-cli/manifest/sha256:654051f51bd9a8c6cb38e5afe46689aeff086cb03f876cd4714a72088e194308?tab=vulnerabilities

## Why is this needed

See above

## How Has This Been Tested?
Going to wait for the github action to test it

## How are existing users impacted? What migration steps/scripts do we need?

Should be no impact

## Checklist:

I have:

- [N/A] updated the documentation and/or roadmap (if required)
- [N/A] added unit or e2e tests
- [N/A] provided instructions on how to upgrade
