### PR TITLE
Update shell.nix (fixes Mac)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -154,7 +154,6 @@ linters:
     - wastedassign
     - whitespace
 
-
   # Disabled linters, due to being misaligned with Go practices
   # - exhaustivestruct
   # - gochecknoglobals

--- a/grpc-server/workflow_test.go
+++ b/grpc-server/workflow_test.go
@@ -71,7 +71,7 @@ func TestCreateWorkflow(t *testing.T) {
 						}, nil
 					},
 					CreateWorkflowFunc: func(ctx context.Context, wf db.Workflow, data string, id uuid.UUID) error {
-						return errors.New("failed to create a workfow")
+						return errors.New("failed to create a workflow")
 					},
 				},
 				wfTemplate: templateID,

--- a/protos/hardware/hardware.pb.go
+++ b/protos/hardware/hardware.pb.go
@@ -122,7 +122,7 @@ func (*Empty) Descriptor() ([]byte, []int) {
 
 //
 // GetRequest is the request used by the Get various get methods exposed by the
-// hardware serice.
+// hardware service.
 type GetRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/protos/hardware/hardware.proto
+++ b/protos/hardware/hardware.proto
@@ -94,7 +94,7 @@ message Empty {
 
 /*
  * GetRequest is the request used by the Get various get methods exposed by the
- * hardware serice.
+ * hardware service.
  */
 message GetRequest {
   string mac = 1;

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,10 @@
 let _pkgs = import <nixpkgs> { };
 in { pkgs ? import (_pkgs.fetchFromGitHub {
   owner = "NixOS";
-  repo = "nixpkgs-channels";
-  #branch@date: nixpkgs-unstable@2020-09-11
-  rev = "6d4b93323e7f78121f8d6db6c59f3889aa1dd931";
-  sha256 = "0g2j41cx2w2an5d9kkqvgmada7ssdxqz1zvjd7hi5vif8ag0v5la";
+  repo = "nixpkgs";
+  #branch@date: 21.11@2021-12-02
+  rev = "21.11";
+  sha256 = "sha256-AjhmbT4UBlJWqxY0ea8a6GU2C2HdKUREkG43oRr3TZg=";
 }) { } }:
 
 with pkgs;
@@ -14,12 +14,12 @@ mkShell {
     git
     gnumake
     gnused
-    go
+    go_1_17
     jq
     nixfmt
     nodePackages.prettier
     protobuf
-    pythonPackages.codespell
+    python3Packages.codespell
     shfmt
     shellcheck
     vagrant


### PR DESCRIPTION
## Description

Update shell.nix

## Why is this needed

`nix-shell` was broken on Mac:

```bash session
tink $ nix-shell
this derivation will be built:
  /nix/store/4qb68dq0paaqrkiv7c4m1kikkxvk4sk3-nixfmt-0.4.0.drv
building '/nix/store/4qb68dq0paaqrkiv7c4m1kikkxvk4sk3-nixfmt-0.4.0.drv'...
setupCompilerEnvironmentPhase
Build with /nix/store/88242sfskrw2mxv2pr4608nwccpw5q41-ghc-8.8.4.
unpacking sources
unpacking source archive /nix/store/l50bqw5ac3vzm9fmqijkxga7hjcnvd5p-nixfmt-0.4.0.tar.gz
source root is nixfmt-0.4.0
setting SOURCE_DATE_EPOCH to timestamp 1000000000 of file nixfmt-0.4.0/src/Nixfmt/Util.hs
patching sources
Replace Cabal file with edited version from mirror://hackage/nixfmt-0.4.0/revision/1.cabal.
Run jailbreak-cabal to lift version restrictions on build inputs.
compileBuildDriverPhase
setupCompileFlags: -package-db=/private/tmp/nix-build-nixfmt-0.4.0.drv-0/setup-package.conf.d -j12 -threaded -rtsopts
[1 of 1] Compiling Main             ( /nix/store/4mdp8nhyfddh7bllbi7xszz7k9955n79-Setup.hs, /private/tmp/nix-build-nixfmt-0.4.0.drv-0/Main.o )
Linking Setup ...
ld: file not found: /usr/lib/system/libcache.dylib for architecture x86_64
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
`cc' failed in phase `Linker'. (Exit code: 1)
error: builder for '/nix/store/4qb68dq0paaqrkiv7c4m1kikkxvk4sk3-nixfmt-0.4.0.drv' failed with exit code 1
```

## How Has This Been Tested?

- [x] CI
- [x] `nix-shell` on both Mac and Linux

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade