### PR TITLE
Add max limit of 2 groups to import blocks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,8 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Fetch Nix Packages
         run: nix-shell --run 'true'
-      - run: ./ci-checks.sh
+      - run: make bin/gofumpt
+      - run: PATH=$PWD/bin/:$PATH ./ci-checks.sh
   validation:
     runs-on: ubuntu-latest
     needs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,12 @@ One must support their proposed changes with unit tests.
 As you submit a pull request(PR) the CI generates a code coverage report.
 It will help you identify parts of the code that are not yet covered in unit tests.
 
+#### Go
+
+##### Import Groups
+
+There should be two groups of import blocks, one for stdlib and the other for everything else.
+
 ## Understanding code structure
 
 This is a nonexhaustive list important packages that happen to cover most of the code base.

--- a/ci-checks.sh
+++ b/ci-checks.sh
@@ -28,6 +28,10 @@ if ! nixfmt shell.nix; then
 	failed=1
 fi
 
+if ! git ls-files '*.go' | xargs -I% sh -c 'sed -i "/^import (/,/^)/ { /^\s*$/ d }" % && gofumpt -w -s %'; then
+	failed=1
+fi
+
 if ! git diff | (! grep .); then
 	failed=1
 fi

--- a/cmd/tink-cli/cmd/get/get.go
+++ b/cmd/tink-cli/cmd/get/get.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/jedib0t/go-pretty/table"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tinkerbell/tink/client"
 	"google.golang.org/grpc"

--- a/db/workflow_test.go
+++ b/db/workflow_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tinkerbell/tink/db"
 	"github.com/tinkerbell/tink/protos/hardware"
 	pb "github.com/tinkerbell/tink/protos/workflow"
-
 	"github.com/tinkerbell/tink/workflow"
 )
 


### PR DESCRIPTION
## Description

Updates CONTRIBUTING.md with a Go style item.
Also enforces the new style via code in ./ci-checks.sh

## Why is this needed

Consistency within the code base.

## How Has This Been Tested?

Ran locally.

## How are existing users impacted? What migration steps/scripts do we need?

NA

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)

