### PR TITLE
Use db.Database interface in grpc server

### DIFF
--- a/grpc-server/grpc_server.go
+++ b/grpc-server/grpc_server.go
@@ -46,7 +46,7 @@ type ConfigGRPCServer struct {
 	Facility      string
 	TLSCert       string
 	GRPCAuthority string
-	DB            *db.TinkDB
+	DB            db.Database
 }
 
 // SetupGRPC setup and return a gRPC server.


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Description

Use the interface type instead of the concrete type

## Why is this needed

Prep work for Tink API using Kubernetes Resource Model

Fixes: 
N/A

## How Has This Been Tested?

Ran tests/verify locally

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
