### PR TITLE
escape pgsql field and values generated by buildGetCondition

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -111,7 +111,7 @@ func get(ctx context.Context, db *sql.DB, query string, args ...interface{}) (st
 func buildGetCondition(fields map[string]string) (string, error) {
 	for column, field := range fields {
 		if field != "" {
-			return fmt.Sprintf("%s = '%s'", column, field), nil
+			return fmt.Sprintf("%s = %s", pq.QuoteIdentifier(column), pq.QuoteLiteral(field)), nil
 		}
 	}
 	return "", errors.New("one GetBy field must be set to build a get condition")


### PR DESCRIPTION
## Description

SQL column names and values should be escaped. Go does not offer a generic function for this (as it tends to be SQL dialect specific).  The "pq" library, which we are using as a Postgresql interface, does provide helpers for this purpose.
 
https://pkg.go.dev/github.com/lib/pq#QuoteIdentifier

Alternatively, `buildGetCondition` is only used by one caller. It should be possible to remove `buildGetCondition` and have `GetTemplate` build a parameterized query with a parameterized list (some SQLs or client libraries don't allow for field names to be parameters, I don't know if that is the case here).
 
## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #574

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
