### PR TITLE
mergify: Change docker-images check more explicit

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,9 @@ queue_rules:
     conditions:
       # Conditions to get out of the queue (= merged)
       - check-success=DCO
-      - check-success=docker-images
+      - check-success~=docker-images.*tink-cli
+      - check-success~=docker-images.*tink-server
+      - check-success~=docker-images.*tink-worker
       - check-success=validation
 
 pull_request_rules:
@@ -14,7 +16,9 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "#review-requested=0"
       - check-success=DCO
-      - check-success=docker-images
+      - check-success~=docker-images.*tink-cli
+      - check-success~=docker-images.*tink-server
+      - check-success~=docker-images.*tink-worker
       - check-success=validation
       - label!=do-not-merge
       - label=ready-to-merge


### PR DESCRIPTION
## Description

Add one explicit `check-success` condition for each of the docker-image actions.

## Why is this needed

The previous check was never matching because mergify was not being given the name of the matrix job, it is only given the realized name for each matrix instance.

We also need to spell each matrix permuation we care about instead of `check-success~=docker-image` because mergify will happily merge once the first image build succeeds, it has not way to know it needs to wait for all of them.

## How Has This Been Tested?

Verified to be valid using [mergify config editor](https://dashboard.mergify.com/github/tinkerbell/repo/tink/config-editor?repositoryName=tink&pullRequestNumber=563)
