### PR TITLE
Use system version of Go

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,6 @@ mkShell {
     git
     gnumake
     gnused
-    go_1_17
     jq
     nixfmt
     nodePackages.prettier


### PR DESCRIPTION
## Description

Drop go from shell.nix (for now) and use the system's go binary.

## Why is this needed

CI is currently breaking because of conflicting go versions.
The better fix would be cutting over fully to nix in CI or reverting this commit once https://github.com/actions/setup-go/pull/175 is merged and released.

## How Has This Been Tested?

CI

## How are existing users impacted? What migration steps/scripts do we need?

CI isn't broken and PRs can be merged.