### PR TITLE
Fix help and usage for `tink template update`

### DIFF
--- a/cmd/tink-cli/cmd/template/update.go
+++ b/cmd/tink-cli/cmd/template/update.go
@@ -21,11 +21,11 @@ func NewUpdateCommand() *cobra.Command {
 		Short: "update a workflow template",
 		Long: `The update command allows you change the definition of an existing workflow template:
 # Update an existing template:
-$ tink template update 614168df-45a5-11eb-b13d-0242ac120003 --file /tmp/example.tmpl
+$ tink template update 614168df-45a5-11eb-b13d-0242ac120003 --path /tmp/example.tmpl
 `,
 		PreRunE: func(c *cobra.Command, args []string) error {
 			if filePath == "" {
-				return fmt.Errorf("%v requires the '--file' flag", c.UseLine())
+				return fmt.Errorf("%v requires the '--path' flag", c.UseLine())
 			}
 			return nil
 		},

--- a/tools.go
+++ b/tools.go
@@ -1,4 +1,5 @@
 //go:build tools
+// +build tools
 
 package tools
 


### PR DESCRIPTION
## Description

`tink template update` previously had the wrong help output (stating argument is `--file` instead of `--path`) and did not support providing the updated template data over stdin.

## Why is this needed

- sandbox users run commands through `docker exec`, so supporting stdin makes it easier for them to use the command
- users should expect the help output to match the expected usage.

## How Has This Been Tested?
TODO

## How are existing users impacted? What migration steps/scripts do we need?

Should not affect existing users, only fix issues users are already encountering.


