### PR TITLE
Fix issue with `tink template update` using stdin

### DIFF
--- a/cmd/tink-cli/cmd/template/update.go
+++ b/cmd/tink-cli/cmd/template/update.go
@@ -59,26 +59,21 @@ $ tink template update 614168df-45a5-11eb-b13d-0242ac120003 --path /tmp/example.
 
 func updateTemplate(id string) {
 	req := template.WorkflowTemplate{Id: id}
-	if filePath != "" {
-		data, err := readTemplateData()
-		if err != nil {
-			log.Fatalf("readTemplateData: %v", err)
-		}
-
-		if data != "" {
-			wf, err := workflow.Parse([]byte(data))
-			if err != nil {
-				log.Fatal(err)
-			}
-			req.Name = wf.Name
-			req.Data = data
-		}
-	} else {
-		log.Fatal("Nothing is provided in the file path")
+	data, err := readTemplateData()
+	if err != nil {
+		log.Fatalf("readTemplateData: %v", err)
 	}
 
-	_, err := client.TemplateClient.UpdateTemplate(context.Background(), &req)
-	if err != nil {
+	if data != "" {
+		wf, err := workflow.Parse([]byte(data))
+		if err != nil {
+			log.Fatal(err)
+		}
+		req.Name = wf.Name
+		req.Data = data
+	}
+
+	if _, err := client.TemplateClient.UpdateTemplate(context.Background(), &req); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("Updated Template: ", id)


### PR DESCRIPTION
## Description

Fixes an issue with `tink template update` using stdin, follow up to #587 

## Why is this needed

#587 didn't fully add support for sdin with `tink template update`, it still threw an error if content wasn't provided using the `--path` argument.

## How Has This Been Tested?
Tested manually against a Tinkerbell environment created using HEAD of sandbox

## How are existing users impacted? What migration steps/scripts do we need?

Existing users not impacted
