### PR TITLE
Get rid of verbose test runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,10 +11,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: "1.17"
+
       - name: make verify
         run: make verify
   test:
@@ -22,20 +24,26 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: "1.17"
+
       - name: Install nix
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+
       - name: Fetch Nix Packages
         run: nix-shell --run 'true'
+
       - name: Generate
         run: nix-shell --run 'make generate'
+
       - name: go test
         run: make test
+
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)
   ci-checks:
@@ -43,19 +51,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install nix
         uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+
       - name: Fetch Nix Packages
         run: nix-shell --run 'true'
+
       - run: make bin/gofumpt
+
       - run: PATH=$PWD/bin/:$PATH ./ci-checks.sh
   validation:
     runs-on: ubuntu-latest
     needs:
       - ci-checks
+
       - test
+
       - verify
     steps:
       - name: fake
@@ -67,26 +81,32 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
           go-version: "1.17"
+
       - run: make crosscompile -j$(nproc)
+
       - name: Upload tink-cli binaries
         uses: actions/upload-artifact@v2
         with:
           name: tink-cli
           path: cmd/tink-cli/tink-cli-*
+
       - name: Upload tink-server binaries
         uses: actions/upload-artifact@v2
         with:
           name: tink-server
           path: cmd/tink-server/tink-server-*
+
       - name: Upload tink-worker binaries
         uses: actions/upload-artifact@v2
         with:
           name: tink-worker
           path: cmd/tink-worker/tink-worker-*
+
       - name: Upload tink-controller binaries
         uses: actions/upload-artifact@v2
         with:
@@ -101,10 +121,13 @@ jobs:
         include:
           - repository: quay.io/tinkerbell/tink-cli
             binary: tink-cli
+
           - repository: quay.io/tinkerbell/tink
             binary: tink-server
+
           - repository: quay.io/tinkerbell/tink-worker
             binary: tink-worker
+
           - repository: quay.io/tinkerbell/tink-controller
             binary: tink-controller
     steps:
@@ -112,8 +135,10 @@ jobs:
         id: docker-image-tag
         run: |
           echo ::set-output name=tags::${{ matrix.repository }}:latest,${{ matrix.repository }}:sha-${GITHUB_SHA::8}
+
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Login to quay.io
         uses: docker/login-action@v1
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}
@@ -121,17 +146,22 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
       - name: Download ${{ matrix.binary }} artifacts
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.binary}}
           path: cmd/${{ matrix.binary }}
+
       - name: Fix Permissions
         run: chmod +x cmd/${{ matrix.binary }}/${{ matrix.binary }}*
+
       - name: ${{ matrix.repository }}
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,10 +34,8 @@ jobs:
         run: nix-shell --run 'true'
       - name: Generate
         run: nix-shell --run 'make generate'
-      - name: go clean -testcache
-        run: go clean -testcache
       - name: go test
-        run: go test -coverprofile=coverage.txt ./... -v
+        run: make test
       - name: upload codecov
         run: bash <(curl -s https://codecov.io/bash)
   ci-checks:

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ images: tink-cli-image tink-server-image tink-worker-image ## Build all docker i
 run: crosscompile run-stack ## Builds and runs the Tink stack (tink, db, cli) via docker-compose
 
 test: ## Run tests
-	go clean -testcache
-	go test -coverprofile=coverage.txt ./... -v
+	go test -coverprofile=coverage.txt ./...
 
 verify: lint check-generated # Verify code style, is lint free, freshness ...
 	gofumpt -s -d .


### PR DESCRIPTION
## Description

This is mostly about getting rid of the `-v` for all the `go test` runs.
Also gets rid of the cleaning the go test cache and adds some empty lines to ci.yaml.

## Why is this needed

I got rid of `-v` as its just not necessary and I feel actually hinders debugging failed tests. When the tests pass I don't really care to see *all* the tests passing, pretty sure everyone just takes it for granted that all the tests are run :D. But when a test fails then the `-v` actually hinders debugging because now you have to go and hunt for the failed test and it's output. Without the `-v` go does the sane thing of only showing the verbose output of the failed test(s). So lets just get rid of the forced `-v`.

I got rid of the `go clean -testcache` calls because I have not found it to be necessary in my day-to-day development. Pretty sure a required use of `go clean -testcache` would be considered a bug in the golang/go. This change was introduced in 8ec0d84b87bd1f291640a46b1e262d24c1c3c5a2 without any reason so I'll just assume there wasn't one.


## How Has This Been Tested?

Lots of `make test` and `go test ./...` for a long time without any breakage.

## How are existing users impacted? What migration steps/scripts do we need?

Faster test runs (by avoiding re-testing unchanged code) and easier to find/debug test failures.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
