### PR TITLE
tink-cli: Add bash to container image

### DIFF
--- a/cmd/tink-cli/Dockerfile
+++ b/cmd/tink-cli/Dockerfile
@@ -4,5 +4,5 @@ CMD sleep infinity
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-RUN apk add --no-cache --update --upgrade ca-certificates
+RUN apk add --no-cache --update --upgrade bash ca-certificates
 COPY tink-cli-linux-${TARGETARCH:-amd64}${TARGETVARIANT} /usr/bin/tink


### PR DESCRIPTION
## Description

Adds bash to tink-cli image

## Why is this needed

I've recently been bitten by alpine/busybox's ash not properly implementing
`[[` as a builtin while doing a bunch of work on sandbox's scripts. Changing
over to POSIX sh is an option but not really worth it imo as almost everyone
assumes sh == bash already and bash is also nice for interactive use anyway.

Bash ends up adding ~2.2MB to the image which I don't think matters, tink-cli
isn't going to be used in production all that much and its still pretty small.

tink-cli-yes-bash                latest            3f59f8e81a34   10 seconds ago   30.4MB
tink-cli-no-bash                 latest            e521b3895111   23 seconds ago   28.2MB

## How Has This Been Tested?

Ran container a bunch of different ways.

## How are existing users impacted? What migration steps/scripts do we need?

Better tink-cli based scripted stuff?

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
