### PR TITLE
Add running workflow for worker index to cache

### DIFF
--- a/pkg/controllers/manager_test.go
+++ b/pkg/controllers/manager_test.go
@@ -1,0 +1,216 @@
+package controllers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tinkerbell/tink/pkg/apis/core/v1alpha1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestWorkflowIndexFuncs(t *testing.T) {
+	cases := []struct {
+		name           string
+		input          client.Object
+		wantAddrs      []string
+		wantStateAddrs []string
+		wantStates     []string
+	}{
+		{
+			"non workflow",
+			&v1alpha1.Hardware{},
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty workflow",
+			&v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					State: "",
+					Tasks: []v1alpha1.Task{},
+				},
+			},
+			[]string{},
+			[]string{},
+			[]string{""},
+		},
+		{
+			"pending workflow",
+			&v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					State: v1alpha1.WorkflowStatePending,
+					Tasks: []v1alpha1.Task{
+						{
+							WorkerAddr: "worker1",
+						},
+					},
+				},
+			},
+			[]string{"worker1"},
+			[]string{"worker1"},
+			[]string{string(v1alpha1.WorkflowStatePending)},
+		},
+		{
+			"running workflow",
+			&v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					State: v1alpha1.WorkflowStateRunning,
+					Tasks: []v1alpha1.Task{
+						{
+							WorkerAddr: "worker1",
+						},
+						{
+							WorkerAddr: "worker2",
+						},
+					},
+				},
+			},
+			[]string{"worker1", "worker2"},
+			[]string{"worker1", "worker2"},
+			[]string{string(v1alpha1.WorkflowStateRunning)},
+		},
+		{
+			"complete workflow",
+			&v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					State: v1alpha1.WorkflowStateSuccess,
+					Tasks: []v1alpha1.Task{
+						{
+							WorkerAddr: "worker1",
+						},
+					},
+				},
+			},
+			[]string{"worker1"},
+			[]string{},
+			[]string{string(v1alpha1.WorkflowStateSuccess)},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotAddr := workflowWorkerAddrIndexFunc(tc.input)
+			if !reflect.DeepEqual(tc.wantAddrs, gotAddr) {
+				t.Errorf("Unexpected wokerAddr response: wanted %#v, got %#v", tc.wantAddrs, gotAddr)
+			}
+			gotStateAddrs := workflowWorkerNonTerminalStateIndexFunc(tc.input)
+			if !reflect.DeepEqual(tc.wantStateAddrs, gotStateAddrs) {
+				t.Errorf("Unexpected non-terminating workflow response: wanted %#v, got %#v", tc.wantStateAddrs, gotStateAddrs)
+			}
+			gotStates := workflowStateIndexFunc(tc.input)
+			if !reflect.DeepEqual(tc.wantStates, gotStates) {
+				t.Errorf("Unexpected workflow state response: wanted %#v, got %#v", tc.wantStates, gotStates)
+			}
+		})
+	}
+}
+
+func TestHardwareIndexFunc(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   client.Object
+		wantMac []string
+		wantIP  []string
+	}{
+		{
+			"non hardware",
+			&v1alpha1.Workflow{},
+			nil,
+			nil,
+		},
+		{
+			"empty hardware dhcp",
+			&v1alpha1.Hardware{
+				Spec: v1alpha1.HardwareSpec{
+					Interfaces: []v1alpha1.Interface{
+						{
+							DHCP: nil,
+						},
+					},
+				},
+			},
+			[]string{},
+			[]string{},
+		},
+		{
+			"blank mac and ip",
+			&v1alpha1.Hardware{
+				Spec: v1alpha1.HardwareSpec{
+					Interfaces: []v1alpha1.Interface{
+						{
+							DHCP: &v1alpha1.DHCP{
+								MAC: "",
+								IP: &v1alpha1.IP{
+									Address: "",
+								},
+							},
+						},
+					},
+				},
+			},
+			[]string{},
+			[]string{},
+		},
+		{
+			"single ip and mac",
+			&v1alpha1.Hardware{
+				Spec: v1alpha1.HardwareSpec{
+					Interfaces: []v1alpha1.Interface{
+						{
+							DHCP: &v1alpha1.DHCP{
+								MAC: "3c:ec:ef:4c:4f:54",
+								IP: &v1alpha1.IP{
+									Address: "172.16.10.100",
+								},
+							},
+						},
+					},
+				},
+			},
+			[]string{"3c:ec:ef:4c:4f:54"},
+			[]string{"172.16.10.100"},
+		},
+		{
+			"double ip and mac",
+			&v1alpha1.Hardware{
+				Spec: v1alpha1.HardwareSpec{
+					Interfaces: []v1alpha1.Interface{
+						{
+							DHCP: &v1alpha1.DHCP{
+								MAC: "3c:ec:ef:4c:4f:54",
+								IP: &v1alpha1.IP{
+									Address: "172.16.10.100",
+								},
+							},
+						},
+						{
+							DHCP: &v1alpha1.DHCP{
+								MAC: "3c:ec:ef:4c:4f:55",
+								IP: &v1alpha1.IP{
+									Address: "172.16.10.101",
+								},
+							},
+						},
+					},
+				},
+			},
+			[]string{"3c:ec:ef:4c:4f:54", "3c:ec:ef:4c:4f:55"},
+			[]string{"172.16.10.100", "172.16.10.101"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMac := hardwareMacIndexFunc(tc.input)
+			if !reflect.DeepEqual(tc.wantMac, gotMac) {
+				t.Errorf("Unexpected response: wanted %#v, got %#v", tc.wantMac, gotMac)
+			}
+			gotIPs := hardwareIPIndexFunc(tc.input)
+			if !reflect.DeepEqual(tc.wantIP, gotIPs) {
+				t.Errorf("Unexpected response: wanted %#v, got %#v", tc.wantIP, gotIPs)
+			}
+		})
+	}
+}

--- a/pkg/controllers/workflow/controller_test.go
+++ b/pkg/controllers/workflow/controller_test.go
@@ -177,7 +177,7 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				Status: v1alpha1.WorkflowStatus{
-					State:         "STATE_PENDING",
+					State:         v1alpha1.WorkflowStatePending,
 					GlobalTimeout: 1800,
 					Tasks: []v1alpha1.Task{
 						{
@@ -199,7 +199,7 @@ func TestReconcile(t *testing.T) {
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
-									Status: "STATE_PENDING",
+									Status: v1alpha1.WorkflowStatePending,
 								},
 							},
 						},
@@ -304,7 +304,7 @@ tasks:
 					},
 				},
 				Status: v1alpha1.WorkflowStatus{
-					State:         "STATE_PENDING",
+					State:         v1alpha1.WorkflowStatePending,
 					GlobalTimeout: 1800,
 					Tasks: []v1alpha1.Task{
 						{
@@ -326,7 +326,7 @@ tasks:
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
-									Status: "STATE_PENDING",
+									Status: v1alpha1.WorkflowStatePending,
 								},
 							},
 						},
@@ -538,7 +538,7 @@ tasks:
 					},
 				},
 				Status: v1alpha1.WorkflowStatus{
-					State:         "STATE_RUNNING",
+					State:         v1alpha1.WorkflowStateRunning,
 					GlobalTimeout: 600,
 					Tasks: []v1alpha1.Task{
 						{
@@ -559,7 +559,7 @@ tasks:
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
-									Status:    "STATE_RUNNING",
+									Status:    v1alpha1.WorkflowStateRunning,
 									StartedAt: TestTime.MetaV1BeforeSec(601),
 								},
 							},
@@ -624,7 +624,7 @@ tasks:
 					},
 				},
 				Status: v1alpha1.WorkflowStatus{
-					State:         "STATE_TIMEOUT",
+					State:         v1alpha1.WorkflowStateTimeout,
 					GlobalTimeout: 600,
 					Tasks: []v1alpha1.Task{
 						{
@@ -645,7 +645,7 @@ tasks:
 										"DEST_DISK":  "/dev/nvme0n1",
 										"IMG_URL":    "http://10.1.1.11:8080/debian-10-openstack-amd64.raw.gz",
 									},
-									Status:    "STATE_TIMEOUT",
+									Status:    v1alpha1.WorkflowStateTimeout,
 									StartedAt: TestTime.MetaV1BeforeSec(601),
 									Seconds:   601,
 									Message:   "Action timed out",


### PR DESCRIPTION
## Description

Adds indexer so clients can query for running workflows by a particular worker address

Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Why is this needed

Boots needs to import this logic and query for these workflows

Fixes: # N/A

## How Has This Been Tested?

Added unit tests for existing and new index functions

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
