### PR TITLE
Make local registry and nginx optional

### DIFF
--- a/cmd/tink-worker/internal/action.go
+++ b/cmd/tink-worker/internal/action.go
@@ -20,10 +20,16 @@ const (
 	infoWaitFinished = "wait finished for failed or timeout container"
 )
 
-func (w *Worker) createContainer(ctx context.Context, cmd []string, wfID string, action *pb.WorkflowAction, captureLogs bool) (string, error) {
-	registry := w.registry
+func (w *Worker) createContainer(ctx context.Context, cmd []string, wfID string, action *pb.WorkflowAction, captureLogs bool, useAbsoluteImageURI bool) (string, error) {
+	var actionImage string
+	if useAbsoluteImageURI {
+		actionImage = action.GetImage()
+	} else {
+		registry := w.registry
+		actionImage = path.Join(registry, action.GetImage())
+	}
 	config := &container.Config{
-		Image:        path.Join(registry, action.GetImage()),
+		Image:        actionImage,
 		AttachStdout: true,
 		AttachStderr: true,
 		Cmd:          cmd,

--- a/cmd/tink-worker/internal/worker.go
+++ b/cmd/tink-worker/internal/worker.go
@@ -104,7 +104,7 @@ func (w *Worker) execute(ctx context.Context, wfID string, action *pb.WorkflowAc
 		return pb.State_STATE_RUNNING, errors.Wrap(err, "pull image")
 	}
 
-	id, err := w.createContainer(ctx, action.Command, wfID, action, captureLogs)
+	id, err := w.createContainer(ctx, action.Command, wfID, action, captureLogs, w.regConn.useAbsoluteImageURI)
 	if err != nil {
 		return pb.State_STATE_RUNNING, errors.Wrap(err, "create container")
 	}
@@ -173,7 +173,7 @@ func (w *Worker) execute(ctx context.Context, wfID string, action *pb.WorkflowAc
 
 // executeReaction executes special case OnTimeout/OnFailure actions.
 func (w *Worker) executeReaction(ctx context.Context, reaction string, cmd []string, wfID string, action *pb.WorkflowAction, captureLogs bool, l log.Logger) pb.State {
-	id, err := w.createContainer(ctx, cmd, wfID, action, captureLogs)
+	id, err := w.createContainer(ctx, cmd, wfID, action, captureLogs, w.regConn.useAbsoluteImageURI)
 	if err != nil {
 		l.Error(errors.Wrap(err, errFailedToRunCmd))
 	}


### PR DESCRIPTION
* Make registry credentials command-line parameters optional to allow
  for public registries

* Allow for action image paths in workflow template as complete URIs
  based on use-absolute-action-image-uri parameter. This will skip
  the prepending of docker-registry to the action image paths.

## Description

<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
