### PR TITLE
[tink-worker] Use workflowID instead of workerID in getWorkflowData

### DIFF
--- a/cmd/tink-worker/worker/worker.go
+++ b/cmd/tink-worker/worker/worker.go
@@ -471,7 +471,7 @@ func (w *Worker) getWorkflowData(ctx context.Context, workflowID string) {
 	}
 
 	if len(res.GetData()) != 0 {
-		wfDir := filepath.Join(w.dataDir, w.workerID)
+		wfDir := filepath.Join(w.dataDir, workflowID)
 		f := openDataFile(wfDir, l)
 		defer func() {
 			if err := f.Close(); err != nil {


### PR DESCRIPTION
## Description

All other workflow data operations in tink-worker are using workflowID, this aligns getWorkflowData to use the same convention.

## Why is this needed

This was causing tink-worker to fail to successfully run through workflows complaining that it couldn't open the right data file for tracking the workflow.

## How Has This Been Tested?

Tested this locally using the sandbox configured to use the latest published components, and a version of tink-worker that I had build and pushed to a registry that I control.

## How are existing users impacted? What migration steps/scripts do we need?

No existing users should be impacted, since the issue does not exist in the previous sandbox release.

