### PR TITLE
Move to path.Join for repo + image_name:

### DIFF
--- a/cmd/tink-worker/worker/registry.go
+++ b/cmd/tink-worker/worker/registry.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
+	"path"
 
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
@@ -42,7 +43,7 @@ func (m *containerManager) PullImage(ctx context.Context, image string) error {
 	}
 	authStr := base64.URLEncoding.EncodeToString(encodedJSON)
 
-	out, err := m.cli.ImagePull(ctx, m.registryDetails.Registry+"/"+image, types.ImagePullOptions{RegistryAuth: authStr})
+	out, err := m.cli.ImagePull(ctx, path.Join(m.registryDetails.Registry, image), types.ImagePullOptions{RegistryAuth: authStr})
 	if err != nil {
 		return errors.Wrap(err, "DOCKER PULL")
 	}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
With this a tink-worker can be started without a registry defined and templates in Tink server can specify any registry.

## Why is this needed

<!--- Link to issue you have raised -->
Currently, if a container registry is not specified then the container image will start with a `/`. This will cause tink worker to fail to pull/run the container. With this change, if a container registry is not specified the `/` will not be added and the contain image will be pulled from the container runtime's default registry. For containerd and docker (which is what Hook runs) the default registry is `docker.io`.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
