### PR TITLE
[tink worker] Make registry CLI flags optional

### DIFF
--- a/cmd/tink-worker/cmd/root.go
+++ b/cmd/tink-worker/cmd/root.go
@@ -93,6 +93,9 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 	rootCmd.Flags().Int64("max-file-size", defaultMaxFileSize, "Maximum file size in bytes (MAX_FILE_SIZE)")
 	rootCmd.Flags().Bool("capture-action-logs", true, "Capture action container output as part of worker logs")
 	rootCmd.Flags().Bool("tinkerbell-tls", true, "Connect to server via TLS or not (TINKERBELL_TLS)")
+	rootCmd.Flags().StringP("docker-registry", "r", "", "Sets the Docker registry (DOCKER_REGISTRY)")
+	rootCmd.Flags().StringP("registry-username", "u", "", "Sets the registry username (REGISTRY_USERNAME)")
+	rootCmd.Flags().StringP("registry-password", "p", "", "Sets the registry-password (REGISTRY_PASSWORD)")
 
 	must := func(err error) {
 		if err != nil {
@@ -102,15 +105,6 @@ func NewRootCommand(version string, logger log.Logger) *cobra.Command {
 
 	rootCmd.Flags().StringP("id", "i", "", "Sets the worker id (ID)")
 	must(rootCmd.MarkFlagRequired("id"))
-
-	rootCmd.Flags().StringP("docker-registry", "r", "", "Sets the Docker registry (DOCKER_REGISTRY)")
-	must(rootCmd.MarkFlagRequired("docker-registry"))
-
-	rootCmd.Flags().StringP("registry-username", "u", "", "Sets the registry username (REGISTRY_USERNAME)")
-	must(rootCmd.MarkFlagRequired("registry-username"))
-
-	rootCmd.Flags().StringP("registry-password", "p", "", "Sets the registry-password (REGISTRY_PASSWORD)")
-	must(rootCmd.MarkFlagRequired("registry-password"))
 
 	rootCmd.Flags().String("tinkerbell-grpc-authority", "", "tink server grpc endpoint (TINKERBELL_GRPC_AUTHORITY)")
 	must(rootCmd.MarkFlagRequired("tinkerbell-grpc-authority"))


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Make `docker-registry`, `registry-username`, and `registry-password` CLI flags optional:

A previous commit allowed an empty registry to be used when running a tink worker action. This allows tink worker to take advantage of that update by not requiring these registry CLI flags.

Currently, if these values are not passed in via `/proc/cmdline` then tink worker will fail to start.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
