### PR TITLE
Add RBAC for tink-controller and tink-server

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,13 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+  - bases/tinkerbell.org_hardware.yaml
+  - bases/tinkerbell.org_templates.yaml
+  - bases/tinkerbell.org_workflows.yaml
+  - bases/tinkerbell.org_workflowdata.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+  - kustomizeconfig.yaml

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -1,0 +1,19 @@
+# This file is for teaching kustomize how to substitute name and namespace reference in CRD
+nameReference:
+  - kind: Service
+    version: v1
+    fieldSpecs:
+      - kind: CustomResourceDefinition
+        version: v1
+        group: apiextensions.k8s.io
+        path: spec/conversion/webhook/clientConfig/service/name
+
+namespace:
+  - kind: CustomResourceDefinition
+    version: v1
+    group: apiextensions.k8s.io
+    path: spec/conversion/webhook/clientConfig/service/namespace
+    create: false
+
+varReference:
+  - path: metadata/annotations

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,0 +1,23 @@
+# Adds namespace to all resources.
+namespace: tink-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: tink-
+
+resources:
+  - namespace.yaml
+
+bases:
+  - ../crd
+  - ../rbac
+  - ../manager
+  - ../server
+  - ../server-rbac
+
+patchesStrategicMerge:
+  - manager_image_patch.yaml
+  - server_image_patch.yaml

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        # Change the value of image field below to your controller image URL
+        - image: tink-controller:latest
+          name: manager

--- a/config/default/namespace.yaml
+++ b/config/default/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system

--- a/config/default/server_image_patch.yaml
+++ b/config/default/server_image_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        # Change the value of image field below to your controller image URL
+        - image: tink-server:latest
+          name: tink-server

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - manager.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+        - image: controller:latest
+          imagePullPolicy: IfNotPresent
+          name: manager
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  # All RBAC will be applied under this service account in
+  # the deployment namespace. You may comment out this resource
+  # if your manager will use a service account that exists at
+  # runtime. Be sure to update RoleBinding and ClusterRoleBinding
+  # subjects if changing service account names.
+  - service_account.yaml
+  - role.yaml
+  - role_binding.yaml
+  - leader_election_role.yaml
+  - leader_election_role_binding.yaml

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -1,0 +1,36 @@
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - hardware
+      - hardware/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - templates
+      - templates/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - workflows
+      - workflows/status
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+  - kind: ServiceAccount
+    name: controller-manager
+    namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system

--- a/config/server-rbac/kustomization.yaml
+++ b/config/server-rbac/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  # All RBAC will be applied under this service account in
+  # the deployment namespace. You may comment out this resource
+  # if your manager will use a service account that exists at
+  # runtime. Be sure to update RoleBinding and ClusterRoleBinding
+  # subjects if changing service account names.
+  - service_account.yaml
+  - role.yaml
+  - role_binding.yaml

--- a/config/server-rbac/role.yaml
+++ b/config/server-rbac/role.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: server-role
+rules:
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - hardware
+      - hardware/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - templates
+      - templates/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - tinkerbell.org
+    resources:
+      - workflows
+      - workflows/status
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/config/server-rbac/role_binding.yaml
+++ b/config/server-rbac/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: server-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: server-role
+subjects:
+  - kind: ServiceAccount
+    name: server
+    namespace: system

--- a/config/server-rbac/service_account.yaml
+++ b/config/server-rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: server
+  namespace: system

--- a/config/server/kustomization.yaml
+++ b/config/server/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - server.yaml

--- a/config/server/server.yaml
+++ b/config/server/server.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+  namespace: system
+  labels:
+    control-plane: server
+spec:
+  selector:
+    matchLabels:
+      control-plane: server
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: server
+      labels:
+        control-plane: server
+    spec:
+      containers:
+        - args:
+            - "--backend=kubernetes"
+            - "--tls=false"
+          image: server:latest
+          imagePullPolicy: IfNotPresent
+          name: tink-server
+          ports:
+            - containerPort: 42113
+              hostPort: 42113
+              name: grpc
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+      serviceAccountName: server
+      terminationGracePeriodSeconds: 10

--- a/kube.mk
+++ b/kube.mk
@@ -15,4 +15,12 @@ generate-manifests: bin/controller-gen # Generate manifests e.g. CRD, RBAC etc.
 		output:crd:dir=./config/crd/bases \
 		output:webhook:dir=./config/webhook \
 		webhook
-	prettier --write ./config/crd/
+	controller-gen \
+		paths=./pkg/controllers/... \
+		output:rbac:dir=./config/rbac/ \
+		rbac:roleName=manager-role
+	controller-gen \
+		paths=./server/... \
+		output:rbac:dir=./config/server-rbac \
+		rbac:roleName=server-role
+	prettier --write ./config/

--- a/pkg/controllers/workflow/controller.go
+++ b/pkg/controllers/workflow/controller.go
@@ -31,6 +31,10 @@ func NewController(kubeClient client.Client) *Controller {
 	}
 }
 
+// +kubebuilder:rbac:groups=tinkerbell.org,resources=hardware;hardware/status,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=tinkerbell.org,resources=templates;templates/status,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=tinkerbell.org,resources=workflows;workflows/status,verbs=get;list;watch;update;patch;delete
+
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	stored := &v1alpha1.Workflow{}
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, stored); err != nil {

--- a/server/kubernetes_api.go
+++ b/server/kubernetes_api.go
@@ -14,6 +14,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// +kubebuilder:rbac:groups=tinkerbell.org,resources=hardware;hardware/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=tinkerbell.org,resources=templates;templates/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=tinkerbell.org,resources=workflows;workflows/status,verbs=get;list;watch;update;patch
+
 // NewKubeBackedServer returns a server that implements the Workflow server interface for a given kubeconfig.
 func NewKubeBackedServer(logger log.Logger, kubeconfig, apiserver string) (*KubernetesBackedServer, error) {
 	ccfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(


### PR DESCRIPTION
## Description
This PR adds all deployment and RBAC manifests and `kustomization.yaml`s for `tink-controller` and `tink-server`.

## Why is this needed
This is needed to help users deploy the kubified tink services in their Kubernetes environment
This is what the generated manifest looks like after running `kustomize build config/default` https://gist.github.com/abhinavmpandey08/ed00314e4b738cacbad67ea9e345ec2a

## How Has This Been Tested?
This has been tested by applying the manifests on a KinD cluster and verifying that `tink-controller` and `tink-server` both work as intended.

## How are existing users impacted? What migration steps/scripts do we need?
No user impact

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
