### PR TITLE
Standardize Kubernetes API flag name

### DIFF
--- a/cmd/tink-controller/main.go
+++ b/cmd/tink-controller/main.go
@@ -27,7 +27,7 @@ type DaemonConfig struct {
 }
 
 func (c *DaemonConfig) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&c.K8sAPI, "kubernetes", "", "The Kubernetes URL")
+	fs.StringVar(&c.K8sAPI, "kubernetes", "", "The Kubernetes API URL, used for in-cluster client construction.")
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")
 }
 

--- a/cmd/tink-server/main.go
+++ b/cmd/tink-server/main.go
@@ -68,7 +68,7 @@ func (c *DaemonConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.TLS, "tls", true, "Run in tls protected mode (disabling should only be done for development or if behind TLS terminating proxy)")
 	fs.StringVar(&c.Backend, "backend", backendPostgres, fmt.Sprintf("The backend datastore to use. Must be one of %s", strings.Join(backends(), ", ")))
 	fs.StringVar(&c.KubeconfigPath, "kubeconfig", "", "The path to the Kubeconfig. Only takes effect if `--backend=kubernetes`")
-	fs.StringVar(&c.KubeAPI, "kube-api", "", "The Kubernetes API endpoint. Only takes effect if `--backend=kubernetes`")
+	fs.StringVar(&c.KubeAPI, "kubernetes", "", "The Kubernetes API URL, used for in-cluster client construction. Only takes effect if `--backend=kubernetes`")
 }
 
 func (c *DaemonConfig) PopulateFromLegacyEnvVar() {


### PR DESCRIPTION
## Description

Kubernetes auto-injects certain [environment variables into pods for service discovery](https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables), and the `KUBERNETES` env var is defined for all pods in all namespaces with the service IP of the API server. Because we already support viper environment variable mappings for flags, changing the flag name here will automatically support the in-cluster Kubernetes client configuration