### PR TITLE
Add clusterctl labels to Tink CRDs to allow them to be moved

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,6 +8,11 @@ resources:
   - bases/tinkerbell.org_workflowdata.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
+# Labels to add to all resources and selectors.
+commonLabels:
+  clusterctl.cluster.x-k8s.io: ""
+  clusterctl.cluster.x-k8s.io/move: ""
+
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
   - kustomizeconfig.yaml


### PR DESCRIPTION
Signed-off-by: Abhinav Pandey <abhinavmpandey08@gmail.com>

## Description
Add these two labels to the Tink CRD definitions:
```yaml
  clusterctl.cluster.x-k8s.io: ""
  clusterctl.cluster.x-k8s.io/move: ""
```

## Why is this needed
Adding these labels allows clusterctl to recognize these objects during cluster move operations 

## How Has This Been Tested?
ran `make release-manifests` and verified that the labels were added properly to the Hardware, Template and Workflow CRDs

## How are existing users impacted? What migration steps/scripts do we need?
No existing user impact


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
