### PR TITLE
Make namespace configurable for tink manifest

### DIFF
--- a/kube.mk
+++ b/kube.mk
@@ -44,6 +44,7 @@ TINK_SERVER_IMAGE ?= quay.io/tinkerbell/tink-server
 TINK_CONTROLLER_IMAGE ?= quay.io/tinkerbell/tink-controller
 TINK_SERVER_TAG ?= latest
 TINK_CONTROLLER_TAG ?= latest
+NAMESPACE ?= tink-system
 
 out/release/default/kustomization.yaml: config/default/kustomization.yaml
 	rm -rf out/
@@ -51,7 +52,10 @@ out/release/default/kustomization.yaml: config/default/kustomization.yaml
 	cp -a config/ out/release/
 
 out/release/tink.yaml: bin/kustomize generate-manifests out/release/default/kustomization.yaml
-	(cd out/release/default && kustomize edit set image server=$(TINK_SERVER_IMAGE):$(TINK_CONTROLLER_TAG) controller=$(TINK_CONTROLLER_IMAGE):$(TINK_CONTROLLER_TAG))
+	(cd out/release/default && \
+		kustomize edit set image server=$(TINK_SERVER_IMAGE):$(TINK_CONTROLLER_TAG) controller=$(TINK_CONTROLLER_IMAGE):$(TINK_CONTROLLER_TAG) && \
+		kustomize edit set namespace $(NAMESPACE) \
+	)
 	kustomize build out/release/default -o $@
 	prettier --write $@
 


### PR DESCRIPTION
Signed-off-by: Abhinav Pandey <abhinavmpandey08@gmail.com>

## Description
Make namespace configurable for tink manifest

## Why is this needed
This is needed to allow users to build and deploy the tink manifest in different namespaces

## How Has This Been Tested?
ran `make release-manifests` and verified the changes

## How are existing users impacted? What migration steps/scripts do we need?
No existing user impact


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
