### PR TITLE
Fix invalid interpolation in docker-compose:

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       ROLLBAR_TOKEN: ${ROLLBAR_TOKEN:-ignored}
       TINKERBELL_GRPC_AUTHORITY: :42113
       TINKERBELL_HTTP_AUTHORITY: :42114
-      TINKERBELL_TLS: ${TINKERBERLL_TLS:"true"}
+      TINKERBELL_TLS: ${TINKERBERLL_TLS:-"true"}
     volumes:
       - certs:/certs/${FACILITY:-onprem}:ro
     ports:
@@ -87,7 +87,7 @@ services:
       PGUSER: tinkerbell
       TINKERBELL_GRPC_AUTHORITY: :42113
       TINKERBELL_HTTP_AUTHORITY: :42114
-      TINKERBELL_TLS: ${TINKERBERLL_TLS:"true"}
+      TINKERBELL_TLS: ${TINKERBERLL_TLS:-"true"}
     depends_on:
       db:
         condition: service_healthy
@@ -109,7 +109,7 @@ services:
       dockerfile: Dockerfile
     environment:
       TINKERBELL_GRPC_AUTHORITY: tink-server:42113
-      TINKERBELL_TLS: ${TINKERBERLL_TLS:"true"}
+      TINKERBELL_TLS: ${TINKERBERLL_TLS:-"true"}
     depends_on:
       tink-server:
         condition: service_healthy


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows `make run` to successfully run and bring up the docker-compose stack.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
