### PR TITLE
Validate mac address on Hardware spec:

### DIFF
--- a/config/crd/bases/tinkerbell.org_hardware.yaml
+++ b/config/crd/bases/tinkerbell.org_hardware.yaml
@@ -108,6 +108,7 @@ spec:
                             format: int64
                             type: integer
                           mac:
+                            pattern: ([0-9a-f]{2}[:]){5}([0-9a-f]{2})
                             type: string
                           name_servers:
                             items:

--- a/pkg/apis/core/v1alpha1/hardware_types.go
+++ b/pkg/apis/core/v1alpha1/hardware_types.go
@@ -115,6 +115,7 @@ type OSIE struct {
 
 // DHCP configuration.
 type DHCP struct {
+	// +kubebuilder:validation:Pattern="([0-9a-f]{2}[:]){5}([0-9a-f]{2})"
 	MAC         string   `json:"mac,omitempty"`
 	Hostname    string   `json:"hostname,omitempty"`
 	LeaseTime   int64    `json:"lease_time,omitempty"`


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This only allows lower case mac addresses. This simplifies matching/looking up mac addresses. Without this values could be upper case or mixed case. Upper case and mixed cases will cause clients to miss lookups if using the wrong case. This standardized to lowercase to remove this error prone interaction.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
