### PR TITLE
Fixed handling of failed task

### DIFF
--- a/server/kubernetes_api_workflow.go
+++ b/server/kubernetes_api_workflow.go
@@ -127,8 +127,7 @@ cont:
 			t := metav1.NewTime(s.nowFunc())
 			return &t
 		}()
-	case pb.State_STATE_FAILED:
-	case pb.State_STATE_TIMEOUT:
+	case pb.State_STATE_FAILED, pb.State_STATE_TIMEOUT:
 		// Handle terminal statuses by updating the workflow state and time
 		wf.Status.State = v1alpha1.WorkflowState(pb.State_name[int32(wfContext.CurrentActionState)])
 		if wf.Status.Tasks[taskIndex].Actions[actionIndex].StartedAt != nil {


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Description

Failed tasks did not properly update the workflow status, and the overall workflow status perpetually showed as `STATE_RUNNING`

## Why is this needed

To properly report a failed workflow

Fixes: #

## How Has This Been Tested?

Added unit tests

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
