### PR TITLE
Error when template for workflow doesn't exist

### DIFF
--- a/pkg/controllers/workflow/controller_test.go
+++ b/pkg/controllers/workflow/controller_test.go
@@ -416,7 +416,7 @@ tasks:
 					ResourceVersion: "999",
 				},
 			},
-			wantErr: nil,
+			wantErr: errors.New("no template found: name=debian; namespace=default"),
 		},
 		// *****
 		{


### PR DESCRIPTION
When the template referenced by a workflow doesn't exist we need to
throw an error to trigger requeueing continuously until the template
becomes available. If it doesn't, logging will indicate as much as it
will note the errors.