### PR TITLE
Fix failure when reporting final action:

### DIFF
--- a/server/dbserver_worker_workflow.go
+++ b/server/dbserver_worker_workflow.go
@@ -97,7 +97,7 @@ func (s *DBServer) ReportActionStatus(ctx context.Context, req *workflow.Workflo
 		}
 	}
 
-	if wfContext.TotalNumberOfActions > 1 && actionIndex == wfContext.TotalNumberOfActions-1 {
+	if wfContext.TotalNumberOfActions > 1 && actionIndex >= wfContext.TotalNumberOfActions {
 		return nil, status.Errorf(codes.FailedPrecondition, errInvalidActionIndex)
 	}
 

--- a/server/dbserver_worker_workflow_test.go
+++ b/server/dbserver_worker_workflow_test.go
@@ -351,6 +351,103 @@ func TestReportActionStatus(t *testing.T) {
 				expectedError: false,
 			},
 		},
+		"report status for final action": {
+			args: args{
+				db: &mock.DB{
+					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
+						return &pb.WorkflowContext{
+							WorkflowId:           workflowID,
+							TotalNumberOfActions: 2,
+							CurrentActionState:   pb.State_STATE_RUNNING,
+							CurrentAction:        actionName,
+						}, nil
+					},
+					GetWorkflowActionsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowActionList, error) {
+						return &pb.WorkflowActionList{
+							ActionList: []*pb.WorkflowAction{
+								{
+									WorkerId: workerID,
+									Image:    actionName,
+									Name:     "first-action",
+									Timeout:  int64(90),
+									TaskName: taskName,
+								},
+								{
+									WorkerId: workerID,
+									Image:    actionName,
+									Name:     actionName,
+									Timeout:  int64(90),
+									TaskName: taskName,
+								},
+							},
+						}, nil
+					},
+					UpdateWorkflowStateFunc: func(ctx context.Context, wfContext *pb.WorkflowContext) error {
+						return nil
+					},
+					InsertIntoWorkflowEventTableFunc: func(ctx context.Context, wfEvent *pb.WorkflowActionStatus, time time.Time) error {
+						return nil
+					},
+				},
+				workflowID:  workflowID,
+				workerID:    workerID,
+				taskName:    taskName,
+				actionName:  actionName,
+				actionState: pb.State_STATE_RUNNING,
+			},
+			want: want{
+				expectedError: false,
+			},
+		},
+		"report status for after final action": {
+			args: args{
+				db: &mock.DB{
+					GetWorkflowContextsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowContext, error) {
+						return &pb.WorkflowContext{
+							WorkflowId:           workflowID,
+							TotalNumberOfActions: 2,
+							CurrentActionState:   pb.State_STATE_SUCCESS,
+							CurrentAction:        actionName,
+							CurrentActionIndex:   2,
+						}, nil
+					},
+					GetWorkflowActionsFunc: func(ctx context.Context, wfID string) (*pb.WorkflowActionList, error) {
+						return &pb.WorkflowActionList{
+							ActionList: []*pb.WorkflowAction{
+								{
+									WorkerId: workerID,
+									Image:    actionName,
+									Name:     "first-action",
+									Timeout:  int64(90),
+									TaskName: taskName,
+								},
+								{
+									WorkerId: workerID,
+									Image:    actionName,
+									Name:     actionName,
+									Timeout:  int64(90),
+									TaskName: taskName,
+								},
+							},
+						}, nil
+					},
+					UpdateWorkflowStateFunc: func(ctx context.Context, wfContext *pb.WorkflowContext) error {
+						return nil
+					},
+					InsertIntoWorkflowEventTableFunc: func(ctx context.Context, wfEvent *pb.WorkflowActionStatus, time time.Time) error {
+						return nil
+					},
+				},
+				workflowID:  workflowID,
+				workerID:    workerID,
+				taskName:    taskName,
+				actionName:  actionName,
+				actionState: pb.State_STATE_RUNNING,
+			},
+			want: want{
+				expectedError: true,
+			},
+		},
 		"report status for second action": {
 			args: args{
 				db: &mock.DB{


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows the final action in a workflow to successfully report its status and consequently allow a workflow to complete.
This issue: https://github.com/tinkerbell/tink/issues/559 incorrectly describes a fix that was applied in this PR: https://github.com/tinkerbell/tink/pull/576

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: https://github.com/tinkerbell/sandbox/issues/143

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests were added and the sandbox (vagrant virtualbox quickstart) was used to manually test.

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [ ] provided instructions on how to upgrade
