### PR TITLE
Issue 505

### DIFF
--- a/cmd/tink-cli/cmd/workflow.go
+++ b/cmd/tink-cli/cmd/workflow.go
@@ -26,7 +26,7 @@ func NewWorkflowCommand() *cobra.Command {
 	cmd.AddCommand(workflow.NewCreateCommand())
 	cmd.AddCommand(workflow.NewDataCommand())
 	cmd.AddCommand(delete.NewDeleteCommand(workflow.NewDeleteOptions()))
-	cmd.AddCommand(workflow.NewShowCommand())
+	cmd.AddCommand(workflow.NewShowCommand(workflow.NewEventsOptions()))
 	cmd.AddCommand(workflow.NewListCommand())
 	cmd.AddCommand(workflow.NewStateCommand())
 

--- a/cmd/tink-cli/cmd/workflow/events.go
+++ b/cmd/tink-cli/cmd/workflow/events.go
@@ -19,11 +19,14 @@ const shortDescr = `show all events for a workflow`
 
 const longDescr = `Prints a table containing all events for a workflow.
 You can specify the kind of output you want to receive.
-It can be table or json.
+It can be table, csv or json.
 `
 
 const exampleDescr = `# Lists all events for a workflow in table output format.
 tink workflow events [id]
+
+# List all workflow in csv output format.
+tink workflow events [id] --format csv
 
 # List a single template in json output format.
 tink workflow events [id] --format json
@@ -74,7 +77,7 @@ func NewShowCommand(opt Options) *cobra.Command {
 				}
 				fmt.Fprint(c.OutOrStdout(), string(b))
 			default:
-				render(allEvents)
+				render(allEvents, opt)
 			}
 
 			return nil
@@ -105,12 +108,16 @@ func fetchEvents(args []string) [][]interface{} {
 	return allEvents
 }
 
-func render(allEvents [][]interface{}) {
+func render(allEvents [][]interface{}, opt Options) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.AppendHeader(table.Row{hWorkerID, hTaskName, hActionName, hExecutionTime, hMessage, hStatus})
 
 	listEvents(t, allEvents)
+	if opt.Format == "csv" {
+		t.RenderCSV()
+		return
+	}
 	t.Render()
 }
 

--- a/cmd/tink-cli/cmd/workflow/events.go
+++ b/cmd/tink-cli/cmd/workflow/events.go
@@ -33,7 +33,7 @@ func NewEventsOptions() Options {
 	return Options{}
 }
 
-func NewShowCommand() *cobra.Command {
+func NewShowCommand(_ Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "events [id]",
 		Short:                 "show all events for a workflow",

--- a/cmd/tink-cli/cmd/workflow/events.go
+++ b/cmd/tink-cli/cmd/workflow/events.go
@@ -23,6 +23,16 @@ var (
 	hStatus        = "Action Status"
 )
 
+type Options struct {
+	// Format specifies the format you want the list of resources printed
+	// out. By default, it is table, but it can be JSON ar CSV.
+	Format string
+}
+
+func NewEventsOptions() Options {
+	return Options{}
+}
+
 func NewShowCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "events [id]",

--- a/cmd/tink-cli/cmd/workflow/events.go
+++ b/cmd/tink-cli/cmd/workflow/events.go
@@ -15,6 +15,20 @@ import (
 	"github.com/tinkerbell/tink/protos/workflow"
 )
 
+const shortDescr = `show all events for a workflow`
+
+const longDescr = `Prints a table containing all events for a workflow.
+You can specify the kind of output you want to receive.
+It can be table or json.
+`
+
+const exampleDescr = `# Lists all events for a workflow in table output format.
+tink workflow events [id]
+
+# List a single template in json output format.
+tink workflow events [id] --format json
+`
+
 var (
 	hWorkerID      = "Worker ID"
 	hTaskName      = "Task Name"
@@ -37,9 +51,10 @@ func NewEventsOptions() Options {
 func NewShowCommand(opt Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "events [id]",
-		Short:                 "show all events for a workflow",
+		Short:                 shortDescr,
+		Long:                  longDescr,
+		Example:               exampleDescr,
 		DisableFlagsInUseLine: true,
-		Example:               "tink workflow events [id]",
 		Args: func(c *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("%v takes an arguments", c.UseLine())


### PR DESCRIPTION
## Description
This PR provides option to get output in 'json' / 'csv' format along with existing tabular format for the tink-cli command 'tink workflow events <id>'.

## Why is this needed
This PR intends to resolve issue as mentioned in https://github.com/tinkerbell/tink/issues/505.

## Fixes:

1. Provide options (format as one of the fields as of now) for 'workflow events' command.
2. Register the options
3. Based on the incoming options format, render table/json/csv.

## How Has This Been Tested?

1. Built images post code changes: `make images`.
2. Started standalone tink-server, tink-cli and postgres via tink repo's docker-compose file: `docker-compose up -d`
3. Exec-ed into tink-cli: `docker exec -it tink_tink-cli_1 sh`
4. Ran command: `tink workflow events <id>`  // lists the events in tabular format
5. Ran command: `tink workflow events <id> --format json` // lists the events in json format
6. Ran command: `tink workflow events <id> --format csv` // lists the events in csv format


## How are existing users impacted? What migration steps/scripts do we need?
No impact to the existing users.
No migration steps/scripts is required.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
