### PR TITLE
Create tags for all services

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -42,7 +42,7 @@ jobs:
           DST_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
           DST_REG_USER: ${{ secrets.QUAY_USERNAME }}
           DST_REG_PASS: ${{ secrets.QUAY_PASSWORD }}
-          
+
       - name: Copy the tink-controller image using skopeo
         run: skopeo copy --all --dest-creds="${DST_REG_USER}":"${DST_REG_PASS}" docker://"${SRC_IMAGE}" docker://"${DST_IMAGE}"
         env:
@@ -50,7 +50,7 @@ jobs:
           DST_IMAGE: ${{ env.REGISTRY }}/tink-controller:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
           DST_REG_USER: ${{ secrets.QUAY_USERNAME }}
           DST_REG_PASS: ${{ secrets.QUAY_PASSWORD }}
-          
+
       - name: Copy the tink-worker image using skopeo
         run: skopeo copy --all --dest-creds="${DST_REG_USER}":"${DST_REG_PASS}" docker://"${SRC_IMAGE}" docker://"${DST_IMAGE}"
         env:
@@ -58,7 +58,7 @@ jobs:
           DST_IMAGE: ${{ env.REGISTRY }}/tink-worker:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
           DST_REG_USER: ${{ secrets.QUAY_USERNAME }}
           DST_REG_PASS: ${{ secrets.QUAY_PASSWORD }}
-          
+
       - name: Copy the tink-cli image using skopeo
         run: skopeo copy --all --dest-creds="${DST_REG_USER}":"${DST_REG_PASS}" docker://"${SRC_IMAGE}" docker://"${DST_IMAGE}"
         env:

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -34,11 +34,36 @@ jobs:
       - name: Set the from image tag
         run: echo "FROM_TAG=sha-${GITHUB_SHA::8}" >> $GITHUB_ENV
 
+      # This is for tink server. quay.io/tinkerbell/tink
       - name: Copy the image using skopeo
         run: skopeo copy --all --dest-creds="${DST_REG_USER}":"${DST_REG_PASS}" docker://"${SRC_IMAGE}" docker://"${DST_IMAGE}"
         env:
           SRC_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.FROM_TAG }}
           DST_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          DST_REG_USER: ${{ secrets.QUAY_USERNAME }}
+          DST_REG_PASS: ${{ secrets.QUAY_PASSWORD }}
+          
+      - name: Copy the tink-controller image using skopeo
+        run: skopeo copy --all --dest-creds="${DST_REG_USER}":"${DST_REG_PASS}" docker://"${SRC_IMAGE}" docker://"${DST_IMAGE}"
+        env:
+          SRC_IMAGE: ${{ env.REGISTRY }}/tink-controller:${{ env.FROM_TAG }}
+          DST_IMAGE: ${{ env.REGISTRY }}/tink-controller:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          DST_REG_USER: ${{ secrets.QUAY_USERNAME }}
+          DST_REG_PASS: ${{ secrets.QUAY_PASSWORD }}
+          
+      - name: Copy the tink-worker image using skopeo
+        run: skopeo copy --all --dest-creds="${DST_REG_USER}":"${DST_REG_PASS}" docker://"${SRC_IMAGE}" docker://"${DST_IMAGE}"
+        env:
+          SRC_IMAGE: ${{ env.REGISTRY }}/tink-worker:${{ env.FROM_TAG }}
+          DST_IMAGE: ${{ env.REGISTRY }}/tink-worker:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+          DST_REG_USER: ${{ secrets.QUAY_USERNAME }}
+          DST_REG_PASS: ${{ secrets.QUAY_PASSWORD }}
+          
+      - name: Copy the tink-cli image using skopeo
+        run: skopeo copy --all --dest-creds="${DST_REG_USER}":"${DST_REG_PASS}" docker://"${SRC_IMAGE}" docker://"${DST_IMAGE}"
+        env:
+          SRC_IMAGE: ${{ env.REGISTRY }}/tink-cli:${{ env.FROM_TAG }}
+          DST_IMAGE: ${{ env.REGISTRY }}/tink-cli:${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
           DST_REG_USER: ${{ secrets.QUAY_USERNAME }}
           DST_REG_PASS: ${{ secrets.QUAY_PASSWORD }}
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Tags were not being pushed to quay.io for services other than quay.io/tinkerbell/tink, this tags tink-controller, tink-worker, and tink-cli with tags as well.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #641 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
