### PR TITLE
Fix tag selection on cli make target

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -13,7 +13,7 @@ SHELL := bash
 
 binaries := cmd/tink-cli/tink-cli cmd/tink-controller/tink-controller cmd/tink-server/tink-server cmd/tink-worker/tink-worker cmd/virtual-worker/virtual-worker
 version := $(shell git rev-parse --short HEAD)
-tag := $(shell git tag --points-at HEAD)
+tag := $(shell git tag --points-at HEAD | head -n 1)
 ifneq (,$(tag))
 version := $(tag)-$(version)
 endif


### PR DESCRIPTION
## Description

This change reduces the number of output displayed by `git tag` command.

## Why is this needed

Some commits (like 9c098c135ff221757e9baa4116900600dbeefe07) contains multiple tags, causing issues during the execution of `make cli`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
$ git clone --depth 1 -b v0.8.0 https://github.com/tinkerbell/tink /tmp/tink
$ cd /tmp/tink
$ make cli
```


## How are existing users impacted? What migration steps/scripts do we need?
NA
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
