### PR TITLE
Clean up tink worker; remove os.Exit; ensure valid container names:

### DIFF
--- a/cmd/tink-worker/cmd/root.go
+++ b/cmd/tink-worker/cmd/root.go
@@ -130,7 +130,6 @@ func initViper(logger log.Logger, cmd *cobra.Command) error {
 			logger.With("configFile", viper.ConfigFileUsed()).Error(err, "could not load config file")
 			return err
 		}
-		logger.Info("no config file found")
 	} else {
 		logger.With("configFile", viper.ConfigFileUsed()).Info("loaded config file")
 	}

--- a/cmd/tink-worker/worker/worker.go
+++ b/cmd/tink-worker/worker/worker.go
@@ -251,12 +251,22 @@ func (w *Worker) ProcessWorkflowActions(ctx context.Context) error {
 	l.Info("starting to process workflow actions")
 
 	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
 		res, err := w.tinkClient.GetWorkflowContexts(ctx, &pb.WorkflowContextRequest{WorkerId: w.workerID})
 		if err != nil {
 			l.Error(errors.Wrap(err, errGetWfContext))
 			<-time.After(5 * time.Second)
 		}
 		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
 			wfContext, err := res.Recv()
 			if err != nil || wfContext == nil {
 				if !errors.Is(err, io.EOF) {

--- a/cmd/tink-worker/worker/worker.go
+++ b/cmd/tink-worker/worker/worker.go
@@ -10,7 +10,6 @@ import (
 	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
 	pb "github.com/tinkerbell/tink/protos/workflow"
-	"google.golang.org/grpc/status"
 )
 
 const (
@@ -161,7 +160,7 @@ func (w *Worker) execute(ctx context.Context, wfID string, action *pb.WorkflowAc
 		return pb.State_STATE_RUNNING, errors.Wrap(err, "create container")
 	}
 
-	l.With("containerID", id, "command", action.GetOnTimeout()).Info("container created")
+	l.With("containerID", id, "command", action.Command).Info("container created")
 
 	var timeCtx context.Context
 	var cancel context.CancelFunc
@@ -259,7 +258,8 @@ func (w *Worker) ProcessWorkflowActions(ctx context.Context) error {
 		res, err := w.tinkClient.GetWorkflowContexts(ctx, &pb.WorkflowContextRequest{WorkerId: w.workerID})
 		if err != nil {
 			l.Error(errors.Wrap(err, errGetWfContext))
-			<-time.After(5 * time.Second)
+			<-time.After(w.retryInterval)
+			continue
 		}
 		for {
 			select {
@@ -272,7 +272,7 @@ func (w *Worker) ProcessWorkflowActions(ctx context.Context) error {
 				if !errors.Is(err, io.EOF) {
 					l.Info(err)
 				}
-				<-time.After(5 * time.Second)
+				<-time.After(w.retryInterval)
 				break
 			}
 			wfID := wfContext.GetWorkflowId()
@@ -314,12 +314,8 @@ func (w *Worker) ProcessWorkflowActions(ctx context.Context) error {
 				}
 			}
 
-			if turn {
-				l := l.With("actionName", actions.GetActionList()[actionIndex].GetName(), "taskName", actions.GetActionList()[actionIndex].GetTaskName())
-				l.Info("starting action")
-			}
-
 			for turn {
+				l.Info("starting action")
 				action := actions.GetActionList()[actionIndex]
 				l := l.With(
 					"actionName", action.GetName(),
@@ -336,12 +332,7 @@ func (w *Worker) ProcessWorkflowActions(ctx context.Context) error {
 						Message:      "Started execution",
 						WorkerId:     action.GetWorkerId(),
 					}
-				RETRY1:
-					if err := w.reportActionStatus(ctx, actionStatus); err != nil {
-						exitWithGrpcError(err, l)
-						<-time.After(5 * time.Second)
-						goto RETRY1
-					}
+					w.reportActionStatus(ctx, l, actionStatus)
 					l.With("status", actionStatus.ActionStatus, "duration", strconv.FormatInt(actionStatus.Seconds, 10)).Info("sent action status")
 				}
 
@@ -366,23 +357,13 @@ func (w *Worker) ProcessWorkflowActions(ctx context.Context) error {
 					}
 					l = l.With("actionStatus", actionStatus.ActionStatus.String())
 					l.Error(err)
-				RETRY2:
-					if err := w.reportActionStatus(ctx, actionStatus); err != nil {
-						exitWithGrpcError(err, l)
-						<-time.After(5 * time.Second)
-						goto RETRY2
-					}
+					w.reportActionStatus(ctx, l, actionStatus)
 					break
 				}
 
 				actionStatus.ActionStatus = pb.State_STATE_SUCCESS
 				actionStatus.Message = "finished execution successfully"
-			RETRY3:
-				if err := w.reportActionStatus(ctx, actionStatus); err != nil {
-					exitWithGrpcError(err, l)
-					<-time.After(5 * time.Second)
-					goto RETRY3
-				}
+				w.reportActionStatus(ctx, l, actionStatus)
 				l.Info("sent action status")
 
 				if len(actions.GetActionList()) == actionIndex+1 {
@@ -405,35 +386,21 @@ func (w *Worker) ProcessWorkflowActions(ctx context.Context) error {
 	}
 }
 
-func exitWithGrpcError(err error, l log.Logger) {
-	if err != nil {
-		errStatus, _ := status.FromError(err)
-		l.With("errorCode", errStatus.Code()).Error(err)
-	}
-}
-
 func isLastAction(wfContext *pb.WorkflowContext, actions *pb.WorkflowActionList) bool {
 	return int(wfContext.GetCurrentActionIndex()) == len(actions.GetActionList())-1
 }
 
-func (w *Worker) reportActionStatus(ctx context.Context, actionStatus *pb.WorkflowActionStatus) error {
-	l := w.getLogger(ctx).With("workflowID", actionStatus.GetWorkflowId(),
-		"workerID", actionStatus.GetWorkerId(),
-		"actionName", actionStatus.GetActionName(),
-		"taskName", actionStatus.GetTaskName(),
-		"status", actionStatus.ActionStatus,
-	)
-	var err error
-	for r := 1; r <= w.retries; r++ {
+// reportActionStatus reports the status of an action to the Tinkerbell server and retries forever on error.
+func (w *Worker) reportActionStatus(ctx context.Context, l log.Logger, actionStatus *pb.WorkflowActionStatus) {
+	for {
 		l.Info("reporting Action Status")
-		_, err = w.tinkClient.ReportActionStatus(ctx, actionStatus)
+		_, err := w.tinkClient.ReportActionStatus(ctx, actionStatus)
 		if err != nil {
 			l.Error(errors.Wrap(err, errReportActionStatus))
 			<-time.After(w.retryInterval)
 
 			continue
 		}
-		return nil
+		return
 	}
-	return err
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Tink API", func() {
 			}, 8*time.Second, 1*time.Second).Should(Equal("STATE_SUCCESS"))
 
 			workerErr := <-errChan
-			Expect(workerErr.Error()).To(Equal("failed to get workflow context: rpc error: code = DeadlineExceeded desc = context deadline exceeded"))
+			Expect(workerErr).To(BeNil())
 		})
 
 		It("02 - should return the correct workflow contexts", func() {

--- a/workflow/template_validator_test.go
+++ b/workflow/template_validator_test.go
@@ -321,8 +321,11 @@ tasks:
 				if err == nil {
 					t.Error("expected error, got nil")
 				}
-				if !strings.Contains(err.Error(), `template: workflow-template:7: unexpected "}" in operand`) {
-					t.Errorf("\nexpected err: '%s'\ngot:          '%s'", `failed to parse template with ID 98788301-d0d9-4ee9-84df-b64e6e1ef1cc: template: workflow-template:7: unexpected "}" in operand`, err)
+				e1 := `template: workflow-template:7: unexpected "}" in operand`
+				e2 := `template: workflow-template:7: bad character U+007D '}'`
+				if !strings.Contains(err.Error(), e1) && !strings.Contains(err.Error(), e2) {
+					base := "failed to parse template with ID 98788301-d0d9-4ee9-84df-b64e6e1ef1cc: "
+					t.Errorf("\nexpected err:    '%s'\nor expected err: '%s'\ngot:             '%s'", base+e1, base+e2, err)
 				}
 			},
 		},


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Removing numerous `os.Exit` calls means that tink
worker wont require a restart for action execution failures. This commit also allows action names to contain spaces without the action failing to run.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #463

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
