### PR TITLE
Adding a default value for hardware metadata state

### DIFF
--- a/api/v1alpha1/hardware_types.go
+++ b/api/v1alpha1/hardware_types.go
@@ -143,6 +143,7 @@ type IP struct {
 }
 
 type HardwareMetadata struct {
+	// +kubebuilder:default:=provisioning
 	State        string                `json:"state,omitempty"`
 	BondingMode  int64                 `json:"bonding_mode,omitempty"`
 	Manufacturer *MetadataManufacturer `json:"manufacturer,omitempty"`

--- a/config/crd/bases/tinkerbell.org_hardware.yaml
+++ b/config/crd/bases/tinkerbell.org_hardware.yaml
@@ -329,6 +329,7 @@ spec:
                           type: string
                       type: object
                     state:
+                      default: provisioning
                       type: string
                   type: object
                 resources:


### PR DESCRIPTION
## Description
The metadata state field is consumed in CAPT for checking if a given hardware is [ready](https://github.com/tinkerbell/cluster-api-provider-tinkerbell/blob/main/controllers/machine.go#L97).

The changes sets a default value for the field to `provisioning` with kubebuilder defaults. Currently this field is left empty.

## Why is this needed
Boots and CAPT looks at `spec.metadata.state` to check if a hardware needs to be PXE served and if a hardware is ready.
Today a user is not expected to set the field but defaulting to `provisioning` helps provide context to the starting state of the tinkerbell provisioning process.
