### PR TITLE
Remove dependency on `packethost/pkg`

### DIFF
--- a/cmd/tink-controller/main.go
+++ b/cmd/tink-controller/main.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/packethost/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -44,28 +42,20 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
-	// Init the packet logger as its used throughout the codebase.
-	logger, err := log.Init("github.com/tinkerbell/tink")
-	if err != nil {
-		panic(err)
-	}
-
 	cmd := NewRootCommand()
-	if err := cmd.ExecuteContext(context.Background()); err != nil {
-		logger.Close()
-		fmt.Fprint(os.Stderr, err.Error())
+	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-	logger.Close()
 }
 
 func NewRootCommand() *cobra.Command {
-	config := &Config{}
-	zapLogger, err := zap.NewProduction()
+	var config Config
+
+	zlog, err := zap.NewProduction()
 	if err != nil {
 		panic(err)
 	}
-	logger := zapr.NewLogger(zapLogger)
+	logger := zapr.NewLogger(zlog).WithName("github.com/tinkerbell/tink")
 
 	cmd := &cobra.Command{
 		Use: "tink-controller",

--- a/cmd/tink-server/main.go
+++ b/cmd/tink-server/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/equinix-labs/otel-init-go/otelinit"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/packethost/pkg/env"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -52,8 +51,13 @@ func (c *Config) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (c *Config) PopulateFromLegacyEnvVar() {
-	c.GRPCAuthority = env.Get("TINKERBELL_GRPC_AUTHORITY", c.GRPCAuthority)
-	c.HTTPAuthority = env.Get("TINKERBELL_HTTP_AUTHORITY", c.HTTPAuthority)
+	if v, ok := os.LookupEnv("TINKERBELL_GRPC_AUTHORITY"); ok {
+		c.GRPCAuthority = v
+	}
+
+	if v, ok := os.LookupEnv("TINKERBELL_HTTP_AUTHORITY"); ok {
+		c.HTTPAuthority = v
+	}
 }
 
 func main() {

--- a/cmd/tink-worker/main.go
+++ b/cmd/tink-worker/main.go
@@ -1,34 +1,17 @@
 package main
 
 import (
-	"context"
 	"os"
 
-	"github.com/equinix-labs/otel-init-go/otelinit"
-	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/tink/cmd/tink-worker/cmd"
-)
-
-const (
-	serviceKey = "github.com/tinkerbell/tink"
 )
 
 // version is set at build time.
 var version = "devel"
 
 func main() {
-	logger, err := log.Init(serviceKey)
-	if err != nil {
-		panic(err)
-	}
-
-	ctx, otelShutdown := otelinit.InitOpenTelemetry(context.Background(), "github.com/tinkerbell/tink")
-
-	rootCmd := cmd.NewRootCommand(version, logger)
+	rootCmd := cmd.NewRootCommand(version)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-
-	logger.Close()
-	otelShutdown(ctx)
 }

--- a/cmd/tink-worker/worker/container_manager_test.go
+++ b/cmd/tink-worker/worker/container_manager_test.go
@@ -10,9 +10,10 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/go-logr/zapr"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/tink/internal/proto"
+	"go.uber.org/zap"
 )
 
 type fakeDockerClient struct {
@@ -131,7 +132,7 @@ func TestContainerManagerCreate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := log.Test(t, "github.com/tinkerbell/tink")
+			logger := zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			mgr := NewContainerManager(logger, newFakeDockerClient(tc.containerID, "", 0, 0, tc.clientErr, nil), RegistryConnDetails{Registry: tc.registry})
 
 			ctx := context.Background()
@@ -177,7 +178,7 @@ func TestContainerManagerStart(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := log.Test(t, "github.com/tinkerbell/tink")
+			logger := zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			mgr := NewContainerManager(logger, newFakeDockerClient(tc.containerID, "", 0, 0, tc.clientErr, nil), RegistryConnDetails{Registry: ""})
 
 			ctx := context.Background()
@@ -249,7 +250,7 @@ func TestContainerManagerWait(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := log.Test(t, "github.com/tinkerbell/tink")
+			logger := zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			mgr := NewContainerManager(logger, newFakeDockerClient(tc.containerID, "", time.Millisecond*20, tc.dockerResponse, tc.clientErr, tc.waitErr), RegistryConnDetails{Registry: ""})
 			ctx, cancel := context.WithTimeout(context.Background(), tc.contextTimeout)
 			defer cancel()
@@ -320,7 +321,7 @@ func TestContainerManagerWaitFailed(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := log.Test(t, "github.com/tinkerbell/tink")
+			logger := zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			mgr := NewContainerManager(logger, newFakeDockerClient(tc.containerID, "", tc.waitTime, tc.dockerResponse, nil, tc.clientErr), RegistryConnDetails{Registry: ""})
 			ctx, cancel := context.WithTimeout(context.Background(), tc.contextTimeout)
 			defer cancel()
@@ -359,7 +360,7 @@ func TestContainerManagerRemove(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := log.Test(t, "github.com/tinkerbell/tink")
+			logger := zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			mgr := NewContainerManager(logger, newFakeDockerClient(tc.containerID, "", 0, 0, tc.clientErr, nil), RegistryConnDetails{Registry: ""})
 
 			ctx := context.Background()

--- a/cmd/tink-worker/worker/log_capturer_test.go
+++ b/cmd/tink-worker/worker/log_capturer_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/packethost/pkg/log"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 )
 
 type fakeDockerLoggerClient struct {
@@ -57,7 +59,7 @@ func TestLogCapturer(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := log.Test(t, "github.com/tinkerbell/tink")
+			logger := zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			ctx := context.Background()
 			clogger := NewDockerLogCapturer(
 				newFakeDockerLoggerClient(tc.content, tc.wanterr),
@@ -75,7 +77,7 @@ func TestLogCapturer(t *testing.T) {
 func TestLogCapturerContextLogger(t *testing.T) {
 	cases := []struct {
 		name   string
-		logger func() *log.Logger
+		logger func() logr.Logger
 		writer bytes.Buffer
 	}{
 		{
@@ -84,9 +86,8 @@ func TestLogCapturerContextLogger(t *testing.T) {
 		},
 		{
 			name: "with context logger",
-			logger: func() *log.Logger {
-				l := log.Test(t, "github.com/tinkerbell/tink/test")
-				return &l
+			logger: func() logr.Logger {
+				return zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			},
 			writer: *bytes.NewBufferString(""),
 		},
@@ -94,7 +95,7 @@ func TestLogCapturerContextLogger(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := log.Test(t, "github.com/tinkerbell/tink")
+			logger := zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			ctx := context.Background()
 			if tc.logger != nil {
 				ctx = context.WithValue(ctx, loggingContextKey, tc.logger())

--- a/cmd/tink-worker/worker/registry.go
+++ b/cmd/tink-worker/worker/registry.go
@@ -49,7 +49,7 @@ func (m *containerManager) PullImage(ctx context.Context, image string) error {
 	}
 	defer func() {
 		if err := out.Close(); err != nil {
-			l.Error(err)
+			l.Error(err, "")
 		}
 	}()
 	fd := json.NewDecoder(out)

--- a/cmd/tink-worker/worker/registry_test.go
+++ b/cmd/tink-worker/worker/registry_test.go
@@ -8,7 +8,8 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
-	"github.com/packethost/pkg/log"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
 )
 
 func (c *fakeDockerClient) ImagePull(context.Context, string, types.ImagePullOptions) (io.ReadCloser, error) {
@@ -49,7 +50,7 @@ func TestContainerManagerPullImage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := log.Test(t, "github.com/tinkerbell/tink")
+			logger := zapr.NewLogger(zap.Must(zap.NewDevelopment()))
 			mgr := NewContainerManager(logger, newFakeDockerClient("", tc.responseContent, 0, 0, tc.clientErr, nil), tc.registry)
 
 			ctx := context.Background()

--- a/cmd/virtual-worker/main.go
+++ b/cmd/virtual-worker/main.go
@@ -3,25 +3,15 @@ package main
 import (
 	"os"
 
-	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/tink/cmd/virtual-worker/cmd"
-)
-
-const (
-	serviceKey = "github.com/tinkerbell/tink"
 )
 
 // version is set at build time.
 var version = "devel"
 
 func main() {
-	logger, err := log.Init(serviceKey)
-	if err != nil {
-		panic(err)
-	}
-	rootCmd := cmd.NewRootCommand(version, logger)
+	rootCmd := cmd.NewRootCommand(version)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
-	logger.Close()
 }

--- a/cmd/virtual-worker/worker/container_manager.go
+++ b/cmd/virtual-worker/worker/container_manager.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/packethost/pkg/log"
+	"github.com/go-logr/logr"
 	"github.com/tinkerbell/tink/cmd/tink-worker/worker"
 	"github.com/tinkerbell/tink/internal/proto"
 )
@@ -26,7 +26,7 @@ type fakeManager struct {
 	sleepJitter time.Duration
 
 	r      *rand.Rand
-	logger log.Logger
+	logger logr.Logger
 }
 
 func (m *fakeManager) sleep() {
@@ -35,7 +35,7 @@ func (m *fakeManager) sleep() {
 }
 
 // NewFakeContainerManager returns a fake worker.ContainerManager that will sleep for Docker API calls.
-func NewFakeContainerManager(l log.Logger, sleepMinimum, sleepJitter time.Duration) worker.ContainerManager {
+func NewFakeContainerManager(l logr.Logger, sleepMinimum, sleepJitter time.Duration) worker.ContainerManager {
 	if sleepMinimum <= 0 {
 		sleepMinimum = 1
 	}
@@ -52,35 +52,35 @@ func NewFakeContainerManager(l log.Logger, sleepMinimum, sleepJitter time.Durati
 }
 
 func (m *fakeManager) CreateContainer(_ context.Context, cmd []string, _ string, _ *proto.WorkflowAction, _, _ bool) (string, error) {
-	m.logger.With("command", cmd).Info("creating container")
+	m.logger.Info("creating container", "command", cmd)
 	return getRandHexStr(m.r, 64), nil
 }
 
 func (m *fakeManager) StartContainer(_ context.Context, id string) error {
-	m.logger.With("containerID", id).Debug("starting container")
+	m.logger.Info("starting container", "containerID", id)
 	return nil
 }
 
 func (m *fakeManager) WaitForContainer(_ context.Context, id string) (proto.State, error) {
-	m.logger.With("containerID", id).Info("waiting for container")
+	m.logger.Info("waiting for container", "containerID", id)
 	m.sleep()
 
 	return proto.State_STATE_SUCCESS, nil
 }
 
 func (m *fakeManager) WaitForFailedContainer(_ context.Context, id string, failedActionStatus chan proto.State) {
-	m.logger.With("containerID", id).Info("waiting for container")
+	m.logger.Info("waiting for container", "containerID", id)
 	m.sleep()
 	failedActionStatus <- proto.State_STATE_SUCCESS
 }
 
 func (m *fakeManager) RemoveContainer(_ context.Context, id string) error {
-	m.logger.With("containerID", id).Info("removing container")
+	m.logger.Info("removing container", "containerID", id)
 	return nil
 }
 
 func (m *fakeManager) PullImage(_ context.Context, image string) error {
-	m.logger.With("image", image).Info("pulling image")
+	m.logger.Info("pulling image", "image", image)
 	m.sleep()
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,17 @@ require (
 )
 
 require (
+	golang.org/x/mod v0.9.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/oauth2 v0.4.0 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/term v0.6.0 // indirect
+	golang.org/x/text v0.8.0 // indirect
+	golang.org/x/time v0.1.0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
+)
+
+require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -73,7 +84,6 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
-	github.com/rollbar/rollbar-go v1.0.2 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
@@ -89,14 +99,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.12.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	golang.org/x/mod v0.9.0 // indirect
-	golang.org/x/net v0.8.0 // indirect
-	golang.org/x/oauth2 v0.4.0 // indirect
-	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.6.0 // indirect
-	golang.org/x/text v0.8.0 // indirect
-	golang.org/x/time v0.1.0 // indirect
-	golang.org/x/tools v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.5
 	github.com/opencontainers/image-spec v1.1.0-rc2
-	github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -609,7 +609,6 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -703,8 +702,6 @@ github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.3.0/go.mod h1:4c3sLeE8xjNqehmF5RpAFLPLJxXscc0R4l6Zg0P1tTQ=
-github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550 h1:/ojL7LAVjyH1MY+db0+j6rcWU3UWWpzHksYFsHWs9vQ=
-github.com/packethost/pkg v0.0.0-20200903155310-0433e0605550/go.mod h1:GSv7cTtIjns4yc0pyajaM1RE/KE4djJONoblFIRDrxA=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
@@ -741,7 +738,6 @@ github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3d
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.28.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
@@ -751,7 +747,6 @@ github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJ
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
-github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
@@ -768,7 +763,6 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rollbar/rollbar-go v1.0.2/go.mod h1:AcFs5f0I+c71bpHlXNNDbOWJiKwjFDtISeXco0L5PKQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -1083,7 +1077,6 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1255,7 +1248,6 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
-google.golang.org/genproto v0.0.0-20190708153700-3bdd9d9f5532/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
@@ -1328,7 +1320,6 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
-google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=

--- a/go.sum
+++ b/go.sum
@@ -768,7 +768,6 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rollbar/rollbar-go v1.0.2 h1:uA3+z0jq6ka9WUUt9VX/xuiQZXZyWRoeKvkhVvLO9Jc=
 github.com/rollbar/rollbar-go v1.0.2/go.mod h1:AcFs5f0I+c71bpHlXNNDbOWJiKwjFDtISeXco0L5PKQ=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Tink API", func() {
 				worker.WithDataDir("./worker"),
 				worker.WithMaxFileSize(1<<10),
 				worker.WithRetries(time.Millisecond*500, 3))
-			logger.With("workerID", workerID).Info("Created worker")
+			logger.Info("Created worker", "workerID", workerID)
 
 			errChan := make(chan error)
 			workerCtx, cancel := context.WithTimeout(ctx, time.Second*8)

--- a/internal/httpserver/http_server.go
+++ b/internal/httpserver/http_server.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/packethost/pkg/log"
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -15,11 +15,11 @@ import (
 var (
 	gitRev    = "unknown"
 	startTime = time.Now()
-	logger    log.Logger
+	logger    logr.Logger
 )
 
 // SetupHTTP setup and return an HTTP server.
-func SetupHTTP(ctx context.Context, logger log.Logger, authority string, errCh chan<- error) {
+func SetupHTTP(ctx context.Context, logger logr.Logger, authority string, errCh chan<- error) {
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/version", getGitRevJSONHandler())
 	http.HandleFunc("/healthz", healthCheckHandler)
@@ -38,7 +38,7 @@ func SetupHTTP(ctx context.Context, logger log.Logger, authority string, errCh c
 	go func() {
 		<-ctx.Done()
 		if err := srv.Shutdown(context.Background()); err != nil {
-			logger.Error(err)
+			logger.Error(err, "shutting down http server")
 		}
 	}()
 }
@@ -74,7 +74,7 @@ func getGitRevJSONHandler() http.HandlerFunc {
 	b, err := json.Marshal(&res)
 	if err != nil {
 		err = errors.Wrap(err, "could not marshal version json")
-		logger.Error(err)
+		logger.Error(err, "")
 		panic(err)
 	}
 

--- a/internal/server/kubernetes_api.go
+++ b/internal/server/kubernetes_api.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
-	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/tink/api/v1alpha1"
 	"github.com/tinkerbell/tink/internal/controller"
 	"github.com/tinkerbell/tink/internal/proto"
@@ -24,7 +24,7 @@ import (
 // +kubebuilder:rbac:groups=tinkerbell.org,resources=workflows;workflows/status,verbs=get;list;watch;update;patch
 
 // NewKubeBackedServer returns a server that implements the Workflow server interface for a given kubeconfig.
-func NewKubeBackedServer(logger log.Logger, kubeconfig, apiserver, namespace string) (*KubernetesBackedServer, error) {
+func NewKubeBackedServer(logger logr.Logger, kubeconfig, apiserver, namespace string) (*KubernetesBackedServer, error) {
 	ccfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
 		&clientcmd.ConfigOverrides{
@@ -56,7 +56,7 @@ func NewKubeBackedServer(logger log.Logger, kubeconfig, apiserver, namespace str
 
 // NewKubeBackedServerFromREST returns a server that implements the Workflow
 // server interface with the given Kubernetes rest client and namespace.
-func NewKubeBackedServerFromREST(logger log.Logger, config *rest.Config, namespace string) (*KubernetesBackedServer, error) {
+func NewKubeBackedServerFromREST(logger logr.Logger, config *rest.Config, namespace string) (*KubernetesBackedServer, error) {
 	clstr, err := cluster.New(config, func(opts *cluster.Options) {
 		opts.Scheme = controller.DefaultScheme()
 		opts.Logger = zapr.NewLogger(zap.NewNop())
@@ -93,7 +93,7 @@ func NewKubeBackedServerFromREST(logger log.Logger, config *rest.Config, namespa
 
 // KubernetesBackedServer is a server that implements a workflow API.
 type KubernetesBackedServer struct {
-	logger     log.Logger
+	logger     logr.Logger
 	ClientFunc func() client.Client
 	namespace  string
 

--- a/internal/server/kubernetes_api_test.go
+++ b/internal/server/kubernetes_api_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/zapr"
 	"github.com/google/go-cmp/cmp"
-	"github.com/packethost/pkg/log"
 	"github.com/tinkerbell/tink/api/v1alpha1"
 	"github.com/tinkerbell/tink/internal/proto"
 	"github.com/tinkerbell/tink/internal/testtime"
+	"go.uber.org/zap"
 )
 
 var TestTime = testtime.NewFrozenTimeUnix(1637361793)
@@ -418,7 +419,7 @@ func TestModifyWorkflowState(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			server := &KubernetesBackedServer{
-				logger:     log.Test(t, "TestModifyWorkflowState"),
+				logger:     zapr.NewLogger(zap.Must(zap.NewDevelopment())),
 				ClientFunc: nil,
 				namespace:  "default",
 				nowFunc:    TestTime.Now,


### PR DESCRIPTION
This change removes the dependency on the `packethost/pkg` module.

Additionally, it adjusts some of the construction logic in root commands to minimize the logic in `main()`.