### PR TITLE
Add Cmd validation for v1alpha2 Template commands

### DIFF
--- a/api/v1alpha2/template.go
+++ b/api/v1alpha2/template.go
@@ -30,11 +30,14 @@ type Action struct {
 	// Image is an OCI image.
 	Image string `json:"image"`
 
-	// Cmd defines the command to use when launching the image.
+	// Cmd defines the command to use when launching the image. It overrides the default command
+	// of the action. It must be a unix path to an executable program.
+	// +kubebuilder:validation:Pattern=`^(/[^/ ]*)+/?$`
 	// +optional
 	Cmd *string `json:"cmd,omitempty"`
 
-	// Args are a set of arguments to be passed to the container on launch.
+	// Args are a set of arguments to be passed to the command executed by the container on
+	// launch.
 	// +optional
 	Args []string `json:"args,omitempty"`
 


### PR DESCRIPTION
We expect action commands configured on templates to be unix paths that reference an executable. This adds a validation to ensure its a single path. 

The command will translate in implementation to a Docker entrypoint which has 2 forms. We're only allowing a single argument as the entrypoint that can accept a number of args `<cmd> <arg1> ...<argN>` for simplicity.