### PR TITLE
Change dependabot frequencies to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,24 +3,26 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "05:00"
+      interval: "daily"
       timezone: "America/New_York"
+    reviewers:
+      - chrisdoherty4
+      - jacobweinstock
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "05:00"
+      interval: "daily"
       timezone: "America/New_York"
-    open-pull-requests-limit: 10
+    reviewers:
+      - chrisdoherty4
+      - jacobweinstock
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "05:00"
+      interval: "daily"
       timezone: "America/New_York"
+    reviewers:
+      - chrisdoherty4
+      - jacobweinstock


### PR DESCRIPTION
## Summary

Increase dependabot frequency to daily - there's no penalty/rate limit to daily updates. This will help spread the load across a week instead of waiting for the influx at the weekend (the original desire that seems less helpful).
