### PR TITLE
Split e2e tests from unit tests:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,10 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "${{ env.GO_VERSION }}"
-      - name: Install nix
-        uses: cachix/install-nix-action@v20
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Install required nix packages
-        run: nix-shell --run 'true'
-      - run: make test
+      - name: Run unit tests
+        run: make test
+      - name: Run e2e tests
+        run: make e2e-test
       - name: Upload codecov
         run: bash <(curl -s https://codecov.io/bash)
   checks:

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ check-proto: generate-proto
 
 .PHONY: verify
 verify: lint check-generated ## Verify code style, is lint free, freshness ...
-	$(GOFUMPT) -s -d .
+	$(GOFUMPT) -d .
 
 .PHONY: lint
 lint: shellcheck hadolint golangci-lint yamllint ## Lint code

--- a/buf.lock
+++ b/buf.lock
@@ -4,4 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 5ae7f88519b04fe1965da0f8a375a088
+    commit: cc916c31859748a68fd229a3c8d7a2e8

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e_test
 
 import (

--- a/internal/e2e/tink_suite_test.go
+++ b/internal/e2e/tink_suite_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e_test
 
 import (


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This makes it clear that there are 2 different types of tests. Also remove nix in CI for tests. The update to the make build target is to improve the output.

current:
```bash
❯ make build
CGO_ENABLED=0 \
GOOS=linux \
GOARCH=amd64 \
go build \
         \
        -o ./bin/tink-server-linux-amd64 \
        ./cmd/tink-server
CGO_ENABLED=0 \
GOOS=linux \
GOARCH=amd64 \
go build \
         \
        -o ./bin/tink-worker-linux-amd64 \
        ./cmd/tink-worker
CGO_ENABLED=0 \
GOOS=linux \
GOARCH=amd64 \
go build \
         \
        -o ./bin/tink-controller-linux-amd64 \
        ./cmd/tink-controller
CGO_ENABLED=0 \
GOOS=linux \
GOARCH=amd64 \
go build \
         \
        -o ./bin/virtual-worker-linux-amd64 \
        ./cmd/virtual-worker
```
new:
```bash
❯ make build
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build  -o ./bin/tink-server-linux-amd64 ./cmd/tink-server 
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build  -o ./bin/tink-worker-linux-amd64 ./cmd/tink-worker 
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build  -o ./bin/tink-controller-linux-amd64 ./cmd/tink-controller 
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build  -o ./bin/virtual-worker-linux-amd64 ./cmd/virtual-worker

```

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
