### PR TITLE
Move ci-checks.sh to a make target:

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,8 @@ jobs:
         uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell --run 'true'
-      - run: PATH=$PWD/bin/:$PATH ./ci-checks.sh
+      - name: Run ci-checks.sh
+        run: nix-shell --run 'make ci-checks'
   # We preemptively build the binaries for efficiency instead of waiting on unit tests to pass
   # hence this doesn't depend on anything.
   build:

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,14 @@ check-proto: generate-proto
 verify: lint check-generated ## Verify code style, is lint free, freshness ...
 	$(GOFUMPT) -s -d .
 
+.PHONY: ci-checks
+ci-checks: ## Run ci-checks.sh script
+	@if type nix-shell 2>&1 > /dev/null; then \
+		./ci-checks.sh; \
+	else \
+		docker run -it --rm -v $${PWD}:/code -w /code nixos/nix nix-shell --run 'make ci-checks'; \
+	fi
+
 .PHONY: lint
 lint: shellcheck hadolint golangci-lint yamllint ## Lint code
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows us to check for nix-shell and use docker if nix-shell is not installed. Update CI to use the make target.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #556 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
