### PR TITLE
Add GOBIN for protoc binaries installs:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,5 +240,5 @@ yamllint: $(YAMLLINT_BIN)
 
 .PHONY: _protoc ## Install all required tools for use with this Makefile.
 _protoc:
-	$(GO) install $(PROTOC_GEN_GO)
-	$(GO) install $(PROTOC_GEN_GO_GRPC)
+	GOBIN=$${PWD}/bin $(GO) install $(PROTOC_GEN_GO)
+	GOBIN=$${PWD}/bin $(GO) install $(PROTOC_GEN_GO_GRPC)

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,8 @@ with pkgs;
 
 mkShell {
   buildInputs = [
+    git
+    gnumake
     jq
     nixfmt
     nodePackages.prettier


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This puts the protoc binaries in our `bin` directory so that they are available when we update the PATH at the top of the Makefile.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
