### PR TITLE
Add additional device naming formats to `formatPartition` template func

### DIFF
--- a/internal/agent/runtime/docker_test.go
+++ b/internal/agent/runtime/docker_test.go
@@ -27,7 +27,7 @@ func TestDockerImageNotPresent(t *testing.T) {
 		t.Fatalf("Received unexpected error: %v", err)
 	}
 
-	image := "alpine"
+	image := "hello-world"
 
 	images, err := clnt.ImageList(context.Background(), types.ImageListOptions{
 		Filters: filters.NewArgs(filters.Arg("reference", image)),

--- a/internal/workflow/template_funcs.go
+++ b/internal/workflow/template_funcs.go
@@ -20,11 +20,12 @@ var templateFuncs = map[string]interface{}{
 //
 //	formatPartition("/dev/nvme0n1", 0) -> /dev/nvme0n1p1
 //	formatPartition("/dev/sda", 1) -> /dev/sda1
+//	formatPartition("/dev/vda", 2) -> /dev/vda2
 func formatPartition(dev string, partition int) string {
 	switch {
 	case strings.HasPrefix(dev, "/dev/nvme"):
 		return fmt.Sprintf("%vp%v", dev, partition)
-	case strings.HasPrefix(dev, "/dev/sd"):
+	case strings.HasPrefix(dev, "/dev/sd"), strings.HasPrefix(dev, "/dev/vd"), strings.HasPrefix(dev, "/dev/hd"):
 		return fmt.Sprintf("%v%v", dev, partition)
 	}
 	return dev


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows for using the formatPartition func for more device types. `vd*` is a device created by virtio. `hd*` for legacy IDE hard disks.

Also use `hello-world` image instead of `alpine` in the `TestDockerImageNotPresent` unit test.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #770 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
