### PR TITLE
Add xvd support to Template device parition rendering

### DIFF
--- a/internal/workflow/template_funcs.go
+++ b/internal/workflow/template_funcs.go
@@ -25,7 +25,10 @@ func formatPartition(dev string, partition int) string {
 	switch {
 	case strings.HasPrefix(dev, "/dev/nvme"):
 		return fmt.Sprintf("%vp%v", dev, partition)
-	case strings.HasPrefix(dev, "/dev/sd"), strings.HasPrefix(dev, "/dev/vd"), strings.HasPrefix(dev, "/dev/hd"):
+	case strings.HasPrefix(dev, "/dev/sd"),
+		strings.HasPrefix(dev, "/dev/vd"),
+		strings.HasPrefix(dev, "/dev/xvd"),
+		strings.HasPrefix(dev, "/dev/hd"):
 		return fmt.Sprintf("%v%v", dev, partition)
 	}
 	return dev


### PR DESCRIPTION
Add `xvd` support support for applying partitions numbers in Tinkerbell Template rendering using the `formatPartition` function. 

`xvd` are a virtual device on Xen virtual machines.