### PR TITLE
docs: rename boots to smee

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The Tinkerbell stack consists of several microservices, and a gRPC API:
 `tink-worker` and `tink-server` communicate over gRPC, and are responsible for processing workflows.
 The CLI is the user-interactive piece for creating workflows and their building blocks, templates and hardware data.
 
-### Boots
+### Smee
 
-[Boots][2] is Tinkerbell's DHCP server.
+[Smee][2] is Tinkerbell's DHCP server.
 It handles DHCP requests, hands out IPs, and serves up iPXE.
 It uses the Tinkerbell client to pull and push hardware data.
 It only responds to a predefined set of MAC addresses so it can be deployed in an existing network without interfering with existing DHCP infrastructure.
@@ -97,7 +97,7 @@ export OTEL_EXPORTER_OTLP_INSECURE=true
 For complete documentation, please visit the Tinkerbell project hosted at [tinkerbell.org](https://tinkerbell.org).
 
 [1]: https://github.com/tinkerbell/tink
-[2]: https://github.com/tinkerbell/boots
+[2]: https://github.com/tinkerbell/smee
 [3]: https://github.com/tinkerbell/hegel
 [4]: https://github.com/tinkerbell/osie
 [5]: https://github.com/tinkerbell/hook


### PR DESCRIPTION
## Description

Boots has at some point been renamed to Smee, but this repo's README did not reflect that change.

## Why is this needed

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [x ] updated the documentation and/or roadmap (if required)
- [x ] added unit or e2e tests
- [ x] provided instructions on how to upgrade
