### PR TITLE
Change gomod dependabot updates to once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,25 +16,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "friday"
       time: "03:52"
       timezone: "America/New_York"
     reviewers:
       - chrisdoherty4
       - jacobweinstock
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "thursday"
-      time: "03:52"
-      timezone: "America/New_York"
-    reviewers:
-      - chrisdoherty4
-      - jacobweinstock
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
We aren't fast enough to justify twice a week updates and projects generally only release once a week anyway so any more is redundant. This changes Go updates to once a week on a Friday giving us the weekend opportunity to handle them.
