### PR TITLE
Update grpc telemetry instrumentation with new APIs

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,4 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 28151c0d0a1641bf938a7672c500e01d
+    commit: a86849a25cc04f4dbe9b15ddddfbc488

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -16,11 +16,7 @@ func NewClientConn(authority string, tls bool) (*grpc.ClientConn, error) {
 		creds = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	conn, err := grpc.Dial(authority,
-		creds,
-		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
-		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
-	)
+	conn, err := grpc.Dial(authority, creds, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 	if err != nil {
 		return nil, errors.Wrap(err, "dial tinkerbell server")
 	}

--- a/internal/grpcserver/grpc_server.go
+++ b/internal/grpcserver/grpc_server.go
@@ -19,14 +19,9 @@ type Registrar interface {
 // SetupGRPC opens a listener and serves a given Registrar's APIs on a gRPC server and returns the listener's address or an error.
 func SetupGRPC(ctx context.Context, r Registrar, listenAddr string, errCh chan<- error) (string, error) {
 	params := []grpc.ServerOption{
-		grpc.ChainUnaryInterceptor(
-			grpcprometheus.UnaryServerInterceptor,
-			otelgrpc.UnaryServerInterceptor(),
-		),
-		grpc.ChainStreamInterceptor(
-			grpcprometheus.StreamServerInterceptor,
-			otelgrpc.StreamServerInterceptor(),
-		),
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.UnaryInterceptor(grpcprometheus.UnaryServerInterceptor),
+		grpc.StreamInterceptor(grpcprometheus.StreamServerInterceptor),
 	}
 
 	// register servers


### PR DESCRIPTION
When updating the gRPC Otel libraries in a dependabot update the verify command passed. However, there are deprecated APIs that we were still using. This updates Tink Worker and Tink Server to use the new Otel gRPC API.