### PR TITLE
Rework build tool installation

### DIFF
--- a/Tools.mk
+++ b/Tools.mk
@@ -1,0 +1,138 @@
+# Define the directory tools are installed to.
+TOOLS_DIR := $(PWD)/out/tools
+
+# Some tools rely on other tools being on the PATH (protoc).
+PATH := $(PATH):$(TOOLS_DIR)
+
+# Define a variable for Go so we can easily change the version we use.
+GO ?= go
+
+LINT_ARCH := $(shell uname -m)
+LINT_OS := $(shell uname)
+LINT_OS_LOWER := $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
+
+BUF_VER := v1.11
+BUF     := $(TOOLS_DIR)/buf-$(BUF_VER)
+
+GOFUMPT_VER := v0.4
+GOFUMPT     := $(TOOLS_DIR)/gofumpt-$(GOFUMPT_VER)
+
+PROTOC_GEN_GO_GRPC_VER := v1.2
+PROTOC_GEN_GO_GRPC     := $(TOOLS_DIR)/protoc-gen-go-grpc
+
+PROTOC_GEN_GO_VER := v1.28
+PROTOC_GEN_GO     := $(TOOLS_DIR)/protoc-gen-go
+
+CONTROLLER_GEN_VER := v0.11
+CONTROLLER_GEN     := $(TOOLS_DIR)/controller-gen-$(CONTROLLER_GEN_VER)
+
+KUSTOMIZE_VER := v4.5
+KUSTOMIZE     := $(TOOLS_DIR)/kustomize-$(KUSTOMIZE_VER)
+
+SETUP_ENVTEST_VER := v0.0.0-20220304125252-9ee63fc65a97
+SETUP_ENVTEST     := $(TOOLS_DIR)/setup-envtest-$(SETUP_ENVTEST_VER)
+
+GOLANGCI_LINT_VER := v1.52
+GOLANGCI_LINT     := $(TOOLS_DIR)/golangci-lint-$(GOLANGCI_LINT_VER)
+
+YAMLFMT_VER := v0.6
+YAMLFMT     := $(TOOLS_DIR)/yamlfmt-$(YAMLFMT_VER)
+
+MOQ_VER := v0.3
+MOQ     := $(TOOLS_DIR)/moq-$(MOQ_VER)
+
+SHELLCHECK_VER := v0.8.0
+SHELLCHECK     := $(TOOLS_DIR)/shellcheck-$(SHELLCHECK_VER)
+
+HADOLINT_VER := v2.12.1-beta
+HADOLINT     := $(TOOLS_DIR)/hadolint-$(HADOLINT_VER)
+
+YAMLLINT_VER  := 1.26.3
+YAMLLINT_ROOT := $(TOOLS_DIR)/yamllint-$(YAMLLINT_VER)
+YAMLLINT_BIN  := $(YAMLLINT_ROOT)/dist/bin/yamllint
+YAMLLINT      := PYTHONPATH=$(YAMLLINT_ROOT)/dist $(YAMLLINT_ROOT)/dist/bin/yamllint
+
+tools: ## Install all tool depedencies.
+tools: $(BUF) $(GOFUMPT) $(PROTOC_GEN_GO_GRPC) $(PROTOC_GEN_GO) $(CONTROLLER_GEN) $(KUSTOMIZE)
+tools: $(SETUP_ENVTEST) $(GOLANGCI_LINT) $(YAMLFMT) $(MOQ) $(SHELLCHECK) $(HADOLINT) $(YAMLLINT_BIN)
+
+$(BUF):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing buf at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install github.com/bufbuild/buf/cmd/buf@$(BUF_VER)
+	@mv $(TOOLS_DIR)/buf $@
+
+$(GOFUMPT):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing gofumpt at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install mvdan.cc/gofumpt@$(GOFUMPT_VER)
+	@mv $(TOOLS_DIR)/gofumpt $@
+
+$(PROTOC_GEN_GO_GRPC):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing protoc-gen-go-grpc at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GEN_GO_GRPC_VER)
+
+$(PROTOC_GEN_GO):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing protoc-gen-go at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VER)
+
+$(CONTROLLER_GEN):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing controller-gen at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VER)
+	@mv $(TOOLS_DIR)/controller-gen $@
+
+$(KUSTOMIZE):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing kustomize at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VER)
+	@mv $(TOOLS_DIR)/kustomize $@
+
+$(SETUP_ENVTEST):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing setup-envtest at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VER)
+	@mv $(TOOLS_DIR)/setup-envtest $@
+
+$(GOLANGCI_LINT):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing golangci-lint at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VER)
+	@mv $(TOOLS_DIR)/golangci-lint $@
+
+$(YAMLFMT):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing yamlfmt at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install github.com/google/yamlfmt/cmd/yamlfmt@$(YAMLFMT_VER)
+	@mv $(TOOLS_DIR)/yamlfmt $@
+
+$(MOQ):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing moq at $@"
+	@GOBIN=$(TOOLS_DIR) $(GO) install github.com/matryer/moq@$(MOQ_VER)
+	@mv $(TOOLS_DIR)/moq $@
+
+$(SHELLCHECK):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing shellcheck at $@"
+	@mkdir -p _tmp
+	@curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VER)/shellcheck-$(SHELLCHECK_VER).$(LINT_OS_LOWER).$(LINT_ARCH).tar.xz | \
+		tar -C _tmp -xJ --strip-components 1 -f -
+	@mv _tmp/shellcheck $@
+	@rm -rf _tmp
+	@chmod u+x $@
+
+$(HADOLINT):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing hadolint at $@"
+	@curl -sSfL -o $@ https://github.com/hadolint/hadolint/releases/download/$(HADOLINT_VER)/hadolint-$(LINT_OS)-$(LINT_ARCH)
+	@chmod u+x $@
+
+$(YAMLLINT_BIN):
+	@mkdir -p $(TOOLS_DIR)
+	@echo "Installing yamllint at $@"
+	@curl -sSfL https://github.com/adrienverge/yamllint/archive/refs/tags/v$(YAMLLINT_VER).tar.gz | \
+		tar -C $(TOOLS_DIR) -zxf -
+	@cd $(YAMLLINT_ROOT) && pip3 install --target dist . > /dev/null || pip install --target dist .

--- a/buf.lock
+++ b/buf.lock
@@ -4,4 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: a86849a25cc04f4dbe9b15ddddfbc488
+    commit: e874a0be2bf140a5a4c7d4122c635823

--- a/config/crd/bases/tinkerbell.org_workflows.yaml
+++ b/config/crd/bases/tinkerbell.org_workflows.yaml
@@ -157,7 +157,7 @@ spec:
             spec:
               properties:
                 hardwareRef:
-                  description: HardwareRef is a reference to a Hardware resource this workflow will execute on. If no namespace is specified the Workflow's namespace is assumed.
+                  description: HardwareRef is a reference to a Hardware resource this workflow will execute on.
                   properties:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -170,7 +170,7 @@ spec:
                   description: "TemplateParams are a list of key-value pairs that are injected into templates at render time. TemplateParams are exposed to templates using a top level .Params key. \n For example, TemplateParams = {\"foo\": \"bar\"}, the foo key can be accessed via .Params.foo."
                   type: object
                 templateRef:
-                  description: TemplateRef is a reference to a Template resource used to render workflow actions. If no namespace is specified the Workflow's namespace is assumed.
+                  description: TemplateRef is a reference to a Template resource used to render workflow actions.
                   properties:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -294,7 +294,7 @@ spec:
                   format: date-time
                   type: string
                 state:
-                  description: State describes the current state of the workflow. For the workflow to enter the WorkflowStateSucceeded state all actions must be in ActionStateSucceeded. The Workflow will enter a WorkflowStateFailed if 1 or more Actions fails.
+                  description: State describes the current state of the Workflow.
                   type: string
               required:
                 - actions


### PR DESCRIPTION
Using `go run` has proven to be slower than installing tools. This PR changes all tools to be installed in `out/tools` and fixes unnecessary reinstallations.