### PR TITLE
Remove default value for Hardware.Spec.Metadata.State:

### DIFF
--- a/Tools.mk
+++ b/Tools.mk
@@ -23,7 +23,7 @@ PROTOC_GEN_GO_GRPC     := $(TOOLS_DIR)/protoc-gen-go-grpc
 PROTOC_GEN_GO_VER := v1.28
 PROTOC_GEN_GO     := $(TOOLS_DIR)/protoc-gen-go
 
-CONTROLLER_GEN_VER := v0.14
+CONTROLLER_GEN_VER := v0.15
 CONTROLLER_GEN     := $(TOOLS_DIR)/controller-gen-$(CONTROLLER_GEN_VER)
 
 KUSTOMIZE_VER := v4.5

--- a/api/v1alpha1/hardware_types.go
+++ b/api/v1alpha1/hardware_types.go
@@ -143,7 +143,6 @@ type IP struct {
 }
 
 type HardwareMetadata struct {
-	// +kubebuilder:default:=provisioning
 	State        string                `json:"state,omitempty"`
 	BondingMode  int64                 `json:"bonding_mode,omitempty"`
 	Manufacturer *MetadataManufacturer `json:"manufacturer,omitempty"`

--- a/config/crd/bases/tinkerbell.org_hardware.yaml
+++ b/config/crd/bases/tinkerbell.org_hardware.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: hardware.tinkerbell.org
 spec:
   group: tinkerbell.org
@@ -343,7 +343,6 @@ spec:
                           type: string
                       type: object
                     state:
-                      default: provisioning
                       type: string
                   type: object
                 resources:
@@ -416,10 +415,15 @@ spec:
                   description: BMCRef references a Rufio Machine object.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         TODO: Add other useful fields. apiVersion, kind, uid?
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -520,10 +524,15 @@ spec:
                   description: OSIE describes the Operating System Installation Environment to be netbooted.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         TODO: Add other useful fields. apiVersion, kind, uid?
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic

--- a/config/crd/bases/tinkerbell.org_osies.yaml
+++ b/config/crd/bases/tinkerbell.org_osies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: osies.tinkerbell.org
 spec:
   group: tinkerbell.org

--- a/config/crd/bases/tinkerbell.org_templates.yaml
+++ b/config/crd/bases/tinkerbell.org_templates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: templates.tinkerbell.org
 spec:
   group: tinkerbell.org

--- a/config/crd/bases/tinkerbell.org_workflows.yaml
+++ b/config/crd/bases/tinkerbell.org_workflows.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: workflows.tinkerbell.org
 spec:
   group: tinkerbell.org
@@ -180,10 +180,15 @@ spec:
                   description: HardwareRef is a reference to a Hardware resource this workflow will execute on.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         TODO: Add other useful fields. apiVersion, kind, uid?
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -201,10 +206,15 @@ spec:
                   description: TemplateRef is a reference to a Template resource used to render workflow actions.
                   properties:
                     name:
+                      default: ""
                       description: |-
                         Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
                         TODO: Add other useful fields. apiVersion, kind, uid?
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This default value doesn't make sense from a holistic point of view. Apply a Hardware object to a cluster doesn't by default indicate the hardware is in a provisioning state and we should not assume this with a default value. It was added as part of some CAPT refactoring. https://github.com/tinkerbell/tink/pull/669 If CAPT needs this state then the responsibility is on CAPT to set this. Also, this field is no longer used by Smee or CAPT.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
