### PR TITLE
add tinkerbell-insecure-tls param to control InsecureSkipVerify

### DIFF
--- a/cmd/tink-worker/cmd/root.go
+++ b/cmd/tink-worker/cmd/root.go
@@ -57,6 +57,7 @@ func NewRootCommand(version string) *cobra.Command {
 			conn, err := client.NewClientConn(
 				viper.GetString("tinkerbell-grpc-authority"),
 				viper.GetBool("tinkerbell-tls"),
+				viper.GetBool("tinkerbell-insecure-tls"),
 			)
 			if err != nil {
 				return err
@@ -104,6 +105,7 @@ func NewRootCommand(version string) *cobra.Command {
 	rootCmd.Flags().Int64("max-file-size", defaultMaxFileSize, "Maximum file size in bytes (MAX_FILE_SIZE)")
 	rootCmd.Flags().Bool("capture-action-logs", true, "Capture action container output as part of worker logs")
 	rootCmd.Flags().Bool("tinkerbell-tls", true, "Connect to server via TLS or not (TINKERBELL_TLS)")
+	rootCmd.Flags().Bool("tinkerbell-insecure-tls", false, "When connecting via TLS, enable insecure TLS via InsecureSkipVerify (TINKERBELL_INSECURE_TLS)")
 	rootCmd.Flags().StringP("docker-registry", "r", "", "Sets the Docker registry (DOCKER_REGISTRY)")
 	rootCmd.Flags().StringP("registry-username", "u", "", "Sets the registry username (REGISTRY_USERNAME)")
 	rootCmd.Flags().StringP("registry-password", "p", "", "Sets the registry-password (REGISTRY_PASSWORD)")

--- a/cmd/virtual-worker/cmd/root.go
+++ b/cmd/virtual-worker/cmd/root.go
@@ -51,6 +51,7 @@ func NewRootCommand(version string) *cobra.Command {
 			conn, err := client.NewClientConn(
 				viper.GetString("tinkerbell-grpc-authority"),
 				viper.GetBool("tinkerbell-tls"),
+				viper.GetBool("tinkerbell-insecure-tls"),
 			)
 			if err != nil {
 				return err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"crypto/tls"
+
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -8,10 +10,10 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func NewClientConn(authority string, tls bool) (*grpc.ClientConn, error) {
+func NewClientConn(authority string, tlsEnabled bool, tlsInsecure bool) (*grpc.ClientConn, error) {
 	var creds grpc.DialOption
-	if tls {
-		creds = grpc.WithTransportCredentials(credentials.NewTLS(nil))
+	if tlsEnabled { // #nosec G402
+		creds = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: tlsInsecure}))
 	} else {
 		creds = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Tink API", func() {
 			}, timeout, interval).Should(Equal("STATE_PENDING"))
 
 			By("Running a virtual worker")
-			conn, err := client.NewClientConn(serverAddr, false)
+			conn, err := client.NewClientConn(serverAddr, false, false)
 			Expect(err).NotTo(HaveOccurred())
 			rClient := proto.NewWorkflowServiceClient(conn)
 
@@ -155,7 +155,7 @@ var _ = Describe("Tink API", func() {
 			}, timeout, interval).Should(Equal("STATE_PENDING"))
 
 			By("Getting Workflow Contexts")
-			conn, err := client.NewClientConn(serverAddr, false)
+			conn, err := client.NewClientConn(serverAddr, false, false)
 			Expect(err).NotTo(HaveOccurred())
 			rClient := proto.NewWorkflowServiceClient(conn)
 			workerID := hardware.Spec.Interfaces[0].DHCP.MAC


### PR DESCRIPTION
#### add tinkerbell-insecure-tls param to control InsecureSkipVerify

- this allows using TLS but without verifying certificates/CAs/hostnames etc
- fix e2e tests for new tlsInsecure parameter
- add `// #nosec G402` so we can actually use InsecureSkipVerify
- make gofumpt happy

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>