### PR TITLE
Remove Template version constraint:

### DIFF
--- a/internal/deprecated/workflow/template_validator.go
+++ b/internal/deprecated/workflow/template_validator.go
@@ -70,10 +70,6 @@ func validate(wf *Workflow) error {
 		return errors.Errorf(errInvalidLength, wf.Name)
 	}
 
-	if wf.Version != "0.1" {
-		return errors.Errorf("invalid template version (%s)", wf.Version)
-	}
-
 	if len(wf.Tasks) == 0 {
 		return errors.New("template must have at least one task defined")
 	}

--- a/internal/deprecated/workflow/template_validator_test.go
+++ b/internal/deprecated/workflow/template_validator_test.go
@@ -84,11 +84,6 @@ func TestValidateTemplate(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:          "template version is invalid",
-			wf:            toWorkflow(withTemplateInvalidVersion()),
-			expectedError: true,
-		},
-		{
 			name:          "template tasks is nil",
 			wf:            toWorkflow(withTemplateNilTasks()),
 			expectedError: true,
@@ -252,12 +247,6 @@ func withTemplateInvalidName() workflowModifier {
 func withTemplateLongName() workflowModifier {
 	return func(wf *Workflow) {
 		wf.Name = veryLongName
-	}
-}
-
-func withTemplateInvalidVersion() workflowModifier {
-	return func(wf *Workflow) {
-		wf.Version = "0.2"
 	}
 }
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The requirement for the Template version to be equal to `0.1` has no basis. This was a construct from the Postgres backend days and even then it was an undocumented and unimplemented idea.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
