### PR TITLE
[tink worker] Don't error when image pull fails and image exists:

### DIFF
--- a/cmd/tink-worker/worker/container_manager_test.go
+++ b/cmd/tink-worker/worker/container_manager_test.go
@@ -26,10 +26,19 @@ type fakeDockerClient struct {
 	statusCode       int
 	err              error
 	waitErr          error
+	imageInspectErr  error
 }
 
-func newFakeDockerClient(containerID, imagePullContent string, delay time.Duration, statusCode int, err, waitErr error) *fakeDockerClient {
-	return &fakeDockerClient{
+type dockerClientOpt func(*fakeDockerClient)
+
+func withImageInspectErr(err error) dockerClientOpt {
+	return func(c *fakeDockerClient) {
+		c.imageInspectErr = err
+	}
+}
+
+func newFakeDockerClient(containerID, imagePullContent string, delay time.Duration, statusCode int, err, waitErr error, opts ...dockerClientOpt) *fakeDockerClient {
+	f := &fakeDockerClient{
 		containerID:      containerID,
 		imagePullContent: imagePullContent,
 		delay:            delay,
@@ -37,6 +46,12 @@ func newFakeDockerClient(containerID, imagePullContent string, delay time.Durati
 		err:              err,
 		waitErr:          waitErr,
 	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
 }
 
 func (c *fakeDockerClient) ContainerCreate(


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
HookOS recently got the capability to embed container images. With this capability, pulling an image is not desired. This is expecially true if the image name is not resolvable or there is no network connection to the registry. An image named `127.0.0.1/embedded/myimage`, for example.

Currently, tink worker will always try to pull an image and will fail if the image pull fails. To allow for embedded images to function properly, when an image pull fails we check if the image already exists in the local Docker cache. If it does we don't fail the method call.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
