### PR TITLE
Add disabling of DHCP per interface:

### DIFF
--- a/api/v1alpha1/hardware_types.go
+++ b/api/v1alpha1/hardware_types.go
@@ -87,6 +87,10 @@ type Interface struct {
 
 	//+optional
 	DHCP *DHCP `json:"dhcp,omitempty"`
+
+	// DisableDHCP disables DHCP for this interface.
+	// +kubebuilder:default=false
+	DisableDHCP bool `json:"disableDhcp,omitempty"`
 }
 
 // Netboot configuration.

--- a/config/crd/bases/tinkerbell.org_hardware.yaml
+++ b/config/crd/bases/tinkerbell.org_hardware.yaml
@@ -124,6 +124,10 @@ spec:
                             pattern: ^(([0-9][0-9]{0,2}|[1-3][0-9][0-9][0-9]|40([0-8][0-9]|9[0-6]))(,[1-9][0-9]{0,2}|[1-3][0-9][0-9][0-9]|40([0-8][0-9]|9[0-6]))*)$
                             type: string
                         type: object
+                      disableDhcp:
+                        default: false
+                        description: DisableDHCP disables DHCP for this interface.
+                        type: boolean
                       netboot:
                         description: Netboot configuration.
                         properties:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Adds flexibility on a per hardware basis that already exists in Smee at a global level.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
