### PR TITLE
Add CAPI labels to Hardware CRD:

### DIFF
--- a/api/v1alpha1/hardware_types.go
+++ b/api/v1alpha1/hardware_types.go
@@ -31,6 +31,8 @@ type HardwareList struct {
 // +kubebuilder:resource:path=hardware,scope=Namespaced,categories=tinkerbell,singular=hardware,shortName=hw
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:JSONPath=".status.state",name=State,type=string
+// +kubebuilder:metadata:labels=clusterctl.cluster.x-k8s.io=
+// +kubebuilder:metadata:labels=clusterctl.cluster.x-k8s.io/move=
 
 // Hardware is the Schema for the Hardware API.
 type Hardware struct {

--- a/cmd/tink-agent/Dockerfile
+++ b/cmd/tink-agent/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20240705-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
 
 COPY bin/tink-agent-${TARGETOS}-${TARGETARCH} /usr/bin/tink-agent
 

--- a/cmd/tink-controller-v1alpha2/Dockerfile
+++ b/cmd/tink-controller-v1alpha2/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20240705-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
 
 COPY bin/tink-controller-v1alpha2-${TARGETOS}-${TARGETARCH} /usr/bin/tink-controller
 

--- a/cmd/tink-controller/Dockerfile
+++ b/cmd/tink-controller/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20240705-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
 
 COPY bin/tink-controller-${TARGETOS}-${TARGETARCH} /usr/bin/tink-controller
 

--- a/cmd/tink-server/Dockerfile
+++ b/cmd/tink-server/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 
 EXPOSE 42113 42114
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20240705-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
 
 COPY bin/tink-server-${TARGETOS}-${TARGETARCH} /usr/bin/tink-server
 

--- a/cmd/tink-worker/Dockerfile
+++ b/cmd/tink-worker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20240705-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
 
 COPY bin/tink-worker-${TARGETOS}-${TARGETARCH} /usr/bin/tink-worker
 

--- a/cmd/virtual-worker/Dockerfile
+++ b/cmd/virtual-worker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20240705-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
 
 COPY bin/virtual-worker-${TARGETOS}-${TARGETARCH} /usr/bin/virtual-worker
 

--- a/config/crd/bases/tinkerbell.org_hardware.yaml
+++ b/config/crd/bases/tinkerbell.org_hardware.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    clusterctl.cluster.x-k8s.io: ""
+    clusterctl.cluster.x-k8s.io/move: ""
   name: hardware.tinkerbell.org
 spec:
   group: tinkerbell.org


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
These labels allow CAPI to move the Hardware CR's during a clusterctl move command. This won't affect non CAPI use.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
