### PR TITLE
Fix Workflow's not moving out of STATE_PREPARING:

### DIFF
--- a/cmd/tink-agent/Dockerfile
+++ b/cmd/tink-agent/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r1
 
 COPY bin/tink-agent-${TARGETOS}-${TARGETARCH} /usr/bin/tink-agent
 

--- a/cmd/tink-controller-v1alpha2/Dockerfile
+++ b/cmd/tink-controller-v1alpha2/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r1
 
 COPY bin/tink-controller-v1alpha2-${TARGETOS}-${TARGETARCH} /usr/bin/tink-controller
 

--- a/cmd/tink-controller/Dockerfile
+++ b/cmd/tink-controller/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r1
 
 COPY bin/tink-controller-${TARGETOS}-${TARGETARCH} /usr/bin/tink-controller
 

--- a/cmd/tink-server/Dockerfile
+++ b/cmd/tink-server/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 
 EXPOSE 42113 42114
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r1
 
 COPY bin/tink-server-${TARGETOS}-${TARGETARCH} /usr/bin/tink-server
 

--- a/cmd/tink-worker/Dockerfile
+++ b/cmd/tink-worker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r1
 
 COPY bin/tink-worker-${TARGETOS}-${TARGETARCH} /usr/bin/tink-worker
 

--- a/cmd/virtual-worker/Dockerfile
+++ b/cmd/virtual-worker/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20.3
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r0
+RUN apk add --no-cache --update --upgrade ca-certificates=20241121-r1
 
 COPY bin/virtual-worker-${TARGETOS}-${TARGETARCH} /usr/bin/virtual-worker
 

--- a/internal/deprecated/workflow/pre.go
+++ b/internal/deprecated/workflow/pre.go
@@ -121,6 +121,7 @@ func (s *state) prepareWorkflow(ctx context.Context) (reconcile.Result, error) {
 			return r, err
 		}
 	}
+	s.workflow.Status.State = v1alpha1.WorkflowStatePending
 
 	return reconcile.Result{}, nil
 }

--- a/internal/deprecated/workflow/pre_test.go
+++ b/internal/deprecated/workflow/pre_test.go
@@ -34,7 +34,11 @@ func TestPrepareWorkflow(t *testing.T) {
 			hardware:     &v1alpha1.Hardware{},
 			wantHardware: &v1alpha1.Hardware{},
 			workflow:     &v1alpha1.Workflow{},
-			wantWorkflow: &v1alpha1.Workflow{},
+			wantWorkflow: &v1alpha1.Workflow{
+				Status: v1alpha1.WorkflowStatus{
+					State: v1alpha1.WorkflowStatePending,
+				},
+			},
 		},
 		"toggle allowPXE": {
 			wantResult: reconcile.Result{},
@@ -82,6 +86,7 @@ func TestPrepareWorkflow(t *testing.T) {
 			},
 			wantWorkflow: &v1alpha1.Workflow{
 				Status: v1alpha1.WorkflowStatus{
+					State: v1alpha1.WorkflowStatePending,
 					BootOptions: v1alpha1.BootOptionsStatus{
 						AllowNetboot: v1alpha1.AllowNetbootStatus{
 							ToggledTrue: true,


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This resolves an issue where a Workflow with only BootOption -> `toggleAllowNetboot: true` will stay indefinitely in a preparing state.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
